### PR TITLE
Add season argument and refactor epi_calendar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: A powerful tool for automating the early detection of seasonal epid
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 URL: https://github.com/ssi-dk/aedseo, https://ssi-dk.github.io/aedseo/
 BugReports: https://github.com/ssi-dk/aedseo/issues
 Suggests:

--- a/R/aedseo.R
+++ b/R/aedseo.R
@@ -111,7 +111,7 @@ aedseo <- function(
 
   # Add the seasons to tsd if available
   if (!is.null(season)) {
-    tsd <- tsd |> dplyr::mutate(season = epi_calendar(time))
+    tsd <- tsd |> dplyr::mutate(season = epi_calendar(.data$time))
   } else {
     tsd <- tsd |> dplyr::mutate(season = "not_defined")
   }

--- a/R/aedseo.R
+++ b/R/aedseo.R
@@ -21,14 +21,14 @@
 #' Choose between "poisson," or "quasipoisson".
 #' @param na_fraction_allowed Numeric value between 0 and 1 specifying the
 #' fraction of observables in the window of size k that are allowed to be NA.
-#' @param season A numeric vector of length 2 c(start,end) with the start and
-#' end weeks of the seasons to stratify the observations by.
-#' Ex: season = c(21,20). Default is NULL.
+#' @param season A numeric vector of length 2, `c(start,end)`, with the start
+#' and end weeks of the seasons to stratify the observations by.
+#' Ex: `season = c(21,20)`. Default, `NULL`, is no stratification by season.
 #'
 #' @return A `aedseo` object containing:
 #'   - 'reference_time': The time point for which the growth rate is estimated.
 #'   - 'observed': The observed value in the reference time point.
-#'   - 'season': A stratification of observables in corresponding seasons.
+#'   - 'season': The stratification of observables in corresponding seasons.
 #'   - 'growth_rate': The estimated growth rate.
 #'   - 'lower_growth_rate': The lower bound of the growth rate's confidence
 #'   interval.
@@ -95,6 +95,8 @@ aedseo <- function(
                             add = coll)
   checkmate::assert_integerish(k, add = coll)
   checkmate::assert_integerish(disease_threshold, add = coll)
+  checkmate::assert_integerish(season, len = 2, lower = 1, upper = 53,
+                               null.ok = TRUE, add = coll)
   checkmate::reportAssertions(coll)
 
   # Throw an error if any of the inputs are not supported
@@ -109,9 +111,9 @@ aedseo <- function(
 
   # Add the seasons to tsd if available
   if (!is.null(season)) {
-    tsd <- tsd |> dplyr::mutate(Season = epi_calendar(time))
+    tsd <- tsd |> dplyr::mutate(season = epi_calendar(time))
   } else {
-    tsd <- tsd |> dplyr::mutate(Season = "Not defined")
+    tsd <- tsd |> dplyr::mutate(season = "not_defined")
   }
 
   for (i in k:n) {
@@ -151,7 +153,7 @@ aedseo <- function(
       tibble::tibble(
         reference_time = tsd$time[i],
         observed = tsd$observed[i],
-        season = tsd$Season[i],
+        season = tsd$season[i],
         growth_rate = growth_rates$estimate[1],
         lower_growth_rate = growth_rates$estimate[2],
         upper_growth_rate = growth_rates$estimate[3],

--- a/R/aedseo.R
+++ b/R/aedseo.R
@@ -22,8 +22,9 @@
 #' @param na_fraction_allowed Numeric value between 0 and 1 specifying the
 #' fraction of observables in the window of size k that are allowed to be NA.
 #' @param season A numeric vector of length 2, `c(start,end)`, with the start
-#' and end weeks of the seasons to stratify the observations by.
-#' Ex: `season = c(21,20)`. Default, `NULL`, is no stratification by season.
+#' and end weeks of the seasons to stratify the observations by. Must spand
+#' the new year; ex: `season = c(21,20)`. Default, `NULL`, is no
+#' stratification by season.
 #'
 #' @return A `aedseo` object containing:
 #'   - 'reference_time': The time point for which the growth rate is estimated.

--- a/R/aedseo.R
+++ b/R/aedseo.R
@@ -68,6 +68,7 @@
 #'   disease_threshold = 200,
 #'   family = "poisson",
 #'   na_fraction_allowed = 0.4,
+#'   season = NULL
 #' )
 #'
 #' # Print the AEDSEO results

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -28,7 +28,7 @@
 #' epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 #' # Expected output: "out_of_season"
 #'
-#' epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
+#' try(epi_calendar(as.Date("2023-01-15"), start = 1, end = 40))
 #' # Expected error: "`start` must be greater than `end`!"
 #'
 #' epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -29,20 +29,23 @@
 #' # Expected output: "out_of_season"
 #'
 #' epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
-#' # Expected output: "out_of_season"
+#' # Expected error: "`start` must be greater than `end`!"
 #'
 #' epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)
 #' # Expected output: "2023/2024"
 epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
+  # Ensure that season spans two years
+  coll <- checkmate::makeAssertCollection()
+  checkmate::assert_integerish(start, add = coll)
+  checkmate::assert_integerish(end, add = coll)
+  if (start < end) coll$push("`start` must be greater than `end`!")
+  checkmate::reportAssertions(coll)
+
   # Compute the current week
   current_week <- as.integer(format(x = date, "%V"))
 
-  # Season is contained to a single year
-  if (start <= end && (dplyr::between(current_week, start, end) |
-                         !dplyr::between(current_week, start, end))) {
-    return("out_of_season")
-    # Season spans new-year
-  } else if (end < start && dplyr::between(current_week, end + 1, start - 1)) {
+  # Ensure that season spans new-year
+  if (end < start && dplyr::between(current_week, end + 1, start - 1)) {
     return("out_of_season")
   }
 

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -31,7 +31,7 @@
 #' epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
 #' # Expected output: "out_of_season"
 #'
-#' epi_calendar(as.Date("2023-10-06")), start = 40, end = 11)
+#' epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)
 #' # Expected output: "2023/2024"
 epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
   # Compute the current week

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -31,7 +31,7 @@
 #' epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
 #' # Expected output: "out_of_season"
 #'
-#' epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
+#' epi_calendar(as.Date("2023-10-06")), start = 40, end = 11)
 #' # Expected output: "2023/2024"
 epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
   # Compute the current week
@@ -42,7 +42,7 @@ epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
                          !dplyr::between(current_week, start, end))) {
     return("out_of_season")
     # Season spans new-year
-  } else if (end < start && dplyr::between(current_week, end, start)) {
+  } else if (end < start && dplyr::between(current_week, end + 1, start - 1)) {
     return("out_of_season")
   }
 

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -3,11 +3,10 @@
 #' @description
 #' `r lifecycle::badge("stable")`
 #'
-#' This function identifies the epidemiological season to which a given date
-#' belongs.
+#' This function identifies the epidemiological season, (spanning two years)
+#' to which a given date belongs.
 #' The epidemiological season is defined by a start and end week, where weeks
-#' are numbered
-#' according to the ISO week date system.
+#' are numbered according to the ISO week date system.
 #'
 #' @param date A date object representing the date to check.
 #' @param start An integer specifying the start week of the epidemiological
@@ -29,8 +28,8 @@
 #' epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 #' # Expected output: "out_of_season"
 #'
-#' epi_calendar(as.Date("2023-01-15"), start = 21, end = 20)
-#' # Expected output: "2022/2023"
+#' epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
+#' # Expected output: "out_of_season"
 #'
 #' epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
 #' # Expected output: "2023/2024"
@@ -38,7 +37,12 @@ epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
   # Compute the current week
   current_week <- as.integer(format(x = date, "%V"))
 
-  if (!(current_week >= start | current_week <= end)) {
+  # Season is contained to a single year
+  if (start <= end && (dplyr::between(current_week, start, end) |
+                         !dplyr::between(current_week, start, end))) {
+    return("out_of_season")
+    # Season spans new-year
+  } else if (end < start && dplyr::between(current_week, end, start)) {
     return("out_of_season")
   }
 

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("stable")`
 #'
-#' This function identifies the epidemiological season, (spanning two years)
+#' This function identifies the epidemiological season, (must span new year)
 #' to which a given date belongs.
 #' The epidemiological season is defined by a start and end week, where weeks
 #' are numbered according to the ISO week date system.

--- a/R/epi_calendar.R
+++ b/R/epi_calendar.R
@@ -23,34 +23,32 @@
 #'
 #' @examples
 #' # Check if a date is within the epidemiological season
-#' epi_calendar(as.Date("2023-09-15"), start = 40, end = 20)
-#' # Expected output: "2022/2023"
+#' epi_calendar(as.Date("2023-09-15"), start = 21, end = 20)
+#' # Expected output: "2023/2024"
 #'
-#' epi_calendar(as.Date("2023-05-01"), start = 40, end = 20)
+#' epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 #' # Expected output: "out_of_season"
 #'
-#' epi_calendar(as.Date("2023-01-15"), start = 40, end = 20)
+#' epi_calendar(as.Date("2023-01-15"), start = 21, end = 20)
 #' # Expected output: "2022/2023"
 #'
-#' epi_calendar(as.Date("2023-12-01"), start = 40, end = 20)
+#' epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
 #' # Expected output: "2023/2024"
-epi_calendar <- Vectorize(function(date, start = 40, end = 20) {
+epi_calendar <- Vectorize(function(date, start = 21, end = 20) {
   # Compute the current week
-  current_week <- as.integer(format(x = date, "%U"))
+  current_week <- as.integer(format(x = date, "%V"))
 
-  if (current_week <= start & end <= current_week) {
+  if (!(current_week >= start | current_week <= end)) {
     return("out_of_season")
   }
 
   # Compute the current year
-  current_year <- format(date, "%Y")
-  # ... and turn into integer
-  current_year_integer <- as.integer(current_year)
+  current_year <- as.integer(strftime(date, format = "%G"))
 
   if (current_week <= end) {
-    ans <- paste0(current_year_integer - 1, "/", current_year_integer)
+    ans <- paste0(current_year - 1, "/", current_year)
   } else {
-    ans <- paste0(current_year_integer, "/", current_year_integer + 1)
+    ans <- paste0(current_year, "/", current_year + 1)
   }
 
   return(ans)

--- a/R/summary.R
+++ b/R/summary.R
@@ -50,8 +50,7 @@ summary.aedseo <- function(object, ...) {
   time_interval <- attr(object, "time_interval")
 
   # Extract the seasons
-  seasons <- unique(object$season)
-  seasons <- paste(seasons, collapse = ", ")
+  seasons <- toString(unique(object$season))
 
   # Latest sum of cases
   latest_sum_of_cases <- object %>%

--- a/R/summary.R
+++ b/R/summary.R
@@ -46,6 +46,13 @@ summary.aedseo <- function(object, ...) {
   # Extract the reference time
   reference_time <- last_observation$reference_time
 
+  # Extract the time_interval
+  time_interval <- attr(object, "time_interval")
+
+  # Extract the seasons
+  seasons <- unique(object$season)
+  seasons <- paste(seasons, collapse = ", ")
+
   # Latest sum of cases
   latest_sum_of_cases <- object %>%
     dplyr::filter(dplyr::row_number() == dplyr::n()) %>%
@@ -102,6 +109,9 @@ summary.aedseo <- function(object, ...) {
     calculation of sum of cases:
       %d
 
+    The time interval for the observations:
+      %s
+
     Disease specific threshold:
       %d
 
@@ -123,9 +133,13 @@ summary.aedseo <- function(object, ...) {
       %s
 
     Latest seasonal onset alarm:
+      %s
+
+    The seasons defined in the series:
       %s",
     family,
     k,
+    time_interval,
     disease_threshold,
     as.character(reference_time),
     latest_sum_of_cases,
@@ -137,7 +151,8 @@ summary.aedseo <- function(object, ...) {
     last_observation$upper_growth_rate,
     sum_of_growth_warnings,
     as.character(latest_growth_warning),
-    as.character(latest_seasonal_onset_alarm)
+    as.character(latest_seasonal_onset_alarm),
+    seasons
   )
 
   # Print the summary message

--- a/man/aedseo-package.Rd
+++ b/man/aedseo-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{aedseo-package}
 \alias{aedseo-package}
-\alias{_PACKAGE}
 \title{aedseo: Automated and Early Detection of Seasonal Epidemic Onset}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}

--- a/man/aedseo.Rd
+++ b/man/aedseo.Rd
@@ -35,16 +35,16 @@ Choose between "poisson," or "quasipoisson".}
 \item{na_fraction_allowed}{Numeric value between 0 and 1 specifying the
 fraction of observables in the window of size k that are allowed to be NA.}
 
-\item{season}{A numeric vector of length 2 c(start,end) with the start and
-end weeks of the seasons to stratify the observations by.
-Ex: season = c(21,20). Default is NULL.}
+\item{season}{A numeric vector of length 2, \code{c(start,end)}, with the start
+and end weeks of the seasons to stratify the observations by.
+Ex: \code{season = c(21,20)}. Default, \code{NULL}, is no stratification by season.}
 }
 \value{
 A \code{aedseo} object containing:
 \itemize{
 \item 'reference_time': The time point for which the growth rate is estimated.
 \item 'observed': The observed value in the reference time point.
-\item 'season': A stratification of observables in corresponding seasons.
+\item 'season': The stratification of observables in corresponding seasons.
 \item 'growth_rate': The estimated growth rate.
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence
 interval.

--- a/man/aedseo.Rd
+++ b/man/aedseo.Rd
@@ -10,7 +10,8 @@ aedseo(
   level = 0.95,
   disease_threshold = NA_integer_,
   family = c("poisson", "quasipoisson"),
-  na_fraction_allowed = 0.4
+  na_fraction_allowed = 0.4,
+  season = NULL
 )
 }
 \arguments{
@@ -23,16 +24,27 @@ aedseo(
 between 0 and 1.}
 
 \item{disease_threshold}{An integer specifying the threshold for considering
-a disease outbreak.}
+a disease outbreak. It defines the per time-step disease threshold that has
+to be surpassed to possibly trigger a seasonal onset alarm. If the total
+number of cases in a window of size k exceeds  \code{disease_threshold * k},
+a seasonal onset alarm can be triggered.}
 
 \item{family}{A character string specifying the family for modeling.
 Choose between "poisson," or "quasipoisson".}
 
+\item{na_fraction_allowed}{Numeric value between 0 and 1 specifying the
+fraction of observables in the window of size k that are allowed to be NA.}
+
+\item{season}{A numeric vector of length 2 c(start,end) with the start and
+end weeks of the seasons to stratify the observations by.
+Ex: season = c(21,20). Default is NULL.}
+}
 \value{
 A \code{aedseo} object containing:
 \itemize{
 \item 'reference_time': The time point for which the growth rate is estimated.
 \item 'observed': The observed value in the reference time point.
+\item 'season': A stratification of observables in corresponding seasons.
 \item 'growth_rate': The estimated growth rate.
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence
 interval.
@@ -44,7 +56,7 @@ zero?
 \item 'sum_of_cases_warning': Logical. Does the Sum of Cases exceed the
 disease threshold?
 \item 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?
-\item 'skipped_window': Logical. Was the window skipped?
+\item 'skipped_window': Logical. Was the window skipped due to missing?
 \item 'converged': Logical. Was the IWLS judged to have converged?
 }
 }
@@ -77,7 +89,8 @@ aedseo_results <- aedseo(
   level = 0.95,
   disease_threshold = 200,
   family = "poisson",
-  na_fraction_allowed = 0.4
+  na_fraction_allowed = 0.4,
+  season = NULL
 )
 
 # Print the AEDSEO results

--- a/man/aedseo.Rd
+++ b/man/aedseo.Rd
@@ -28,9 +28,6 @@ a disease outbreak.}
 \item{family}{A character string specifying the family for modeling.
 Choose between "poisson," or "quasipoisson".}
 
-\item{na_fraction_allowed}{A fraction that determines how many NA values
-that are allowed in the observations for each k window}
-}
 \value{
 A \code{aedseo} object containing:
 \itemize{

--- a/man/aedseo.Rd
+++ b/man/aedseo.Rd
@@ -36,8 +36,9 @@ Choose between "poisson," or "quasipoisson".}
 fraction of observables in the window of size k that are allowed to be NA.}
 
 \item{season}{A numeric vector of length 2, \code{c(start,end)}, with the start
-and end weeks of the seasons to stratify the observations by.
-Ex: \code{season = c(21,20)}. Default, \code{NULL}, is no stratification by season.}
+and end weeks of the seasons to stratify the observations by. Must spand
+the new year; ex: \code{season = c(21,20)}. Default, \code{NULL}, is no
+stratification by season.}
 }
 \value{
 A \code{aedseo} object containing:

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -38,7 +38,7 @@ epi_calendar(as.Date("2023-09-15"), start = 21, end = 20)
 epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 # Expected output: "out_of_season"
 
-epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
+try(epi_calendar(as.Date("2023-01-15"), start = 1, end = 40))
 # Expected error: "`start` must be greater than `end`!"
 
 epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -25,7 +25,7 @@ the epidemiological season.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-This function identifies the epidemiological season, (spanning two years)
+This function identifies the epidemiological season, (must span new year)
 to which a given date belongs.
 The epidemiological season is defined by a start and end week, where weeks
 are numbered according to the ISO week date system.

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -34,9 +34,9 @@ according to the ISO week date system.
 \examples{
 # Check if a date is within the epidemiological season
 epi_calendar(as.Date("2023-09-15"), start = 21, end = 20)
-# Expected output: "2022/2023"
+# Expected output: "2023/2024"
 
-epi_calendar(as.Date("2023-09-15"), start = 40, end = 20)
+epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 # Expected output: "out_of_season"
 
 epi_calendar(as.Date("2023-01-15"), start = 21, end = 20)

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -4,7 +4,7 @@
 \alias{epi_calendar}
 \title{Determine Epidemiological Season}
 \usage{
-epi_calendar(date, start = 40, end = 20)
+epi_calendar(date, start = 21, end = 20)
 }
 \arguments{
 \item{date}{A date object representing the date to check.}
@@ -33,15 +33,15 @@ according to the ISO week date system.
 }
 \examples{
 # Check if a date is within the epidemiological season
-epi_calendar(as.Date("2023-09-15"), start = 40, end = 20)
+epi_calendar(as.Date("2023-09-15"), start = 21, end = 20)
 # Expected output: "2022/2023"
 
-epi_calendar(as.Date("2023-05-01"), start = 40, end = 20)
+epi_calendar(as.Date("2023-09-15"), start = 40, end = 20)
 # Expected output: "out_of_season"
 
-epi_calendar(as.Date("2023-01-15"), start = 40, end = 20)
+epi_calendar(as.Date("2023-01-15"), start = 21, end = 20)
 # Expected output: "2022/2023"
 
-epi_calendar(as.Date("2023-12-01"), start = 40, end = 20)
+epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
 # Expected output: "2023/2024"
 }

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -25,11 +25,10 @@ the epidemiological season.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-This function identifies the epidemiological season to which a given date
-belongs.
+This function identifies the epidemiological season, (spanning two years)
+to which a given date belongs.
 The epidemiological season is defined by a start and end week, where weeks
-are numbered
-according to the ISO week date system.
+are numbered according to the ISO week date system.
 }
 \examples{
 # Check if a date is within the epidemiological season
@@ -39,8 +38,8 @@ epi_calendar(as.Date("2023-09-15"), start = 21, end = 20)
 epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 # Expected output: "out_of_season"
 
-epi_calendar(as.Date("2023-01-15"), start = 21, end = 20)
-# Expected output: "2022/2023"
+epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
+# Expected output: "out_of_season"
 
 epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
 # Expected output: "2023/2024"

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -41,6 +41,6 @@ epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
 # Expected output: "out_of_season"
 
-epi_calendar(as.Date("2023-10-06")), start = 40, end = 11)
+epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)
 # Expected output: "2023/2024"
 }

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -41,6 +41,6 @@ epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
 # Expected output: "out_of_season"
 
-epi_calendar(as.Date("2023-12-01"), start = 21, end = 20)
+epi_calendar(as.Date("2023-10-06")), start = 40, end = 11)
 # Expected output: "2023/2024"
 }

--- a/man/epi_calendar.Rd
+++ b/man/epi_calendar.Rd
@@ -39,7 +39,7 @@ epi_calendar(as.Date("2023-05-30"), start = 40, end = 20)
 # Expected output: "out_of_season"
 
 epi_calendar(as.Date("2023-01-15"), start = 1, end = 40)
-# Expected output: "out_of_season"
+# Expected error: "`start` must be greater than `end`!"
 
 epi_calendar(as.Date("2023-10-06"), start = 40, end = 11)
 # Expected output: "2023/2024"

--- a/tests/testthat/test-epi_calendar.R
+++ b/tests/testthat/test-epi_calendar.R
@@ -29,17 +29,21 @@ test_that("Outside the season, 'out_of_season' is returned", {
 
 # Test if algorithm returns out_of_season when start:end only spand one year
 test_that("Within one year, out_of_season is returned", {
-  expect_equal(
-    epi_calendar(as.Date("2023-03-15"), start = 2, end = 5), "out_of_season"
+  expect_error(
+    epi_calendar(as.Date("2023-03-15"), start = 2, end = 5),
+    "`start` must be greater than `end`!"
   )
-  expect_equal(
-    epi_calendar(as.Date("2023-05-01"), start = 1, end = 53), "out_of_season"
+  expect_error(
+    epi_calendar(as.Date("2023-05-01"), start = 1, end = 53),
+    "`start` must be greater than `end`!"
   )
-  expect_equal(
-    epi_calendar(as.Date("2023-01-15"), start = 30, end = 40), "out_of_season"
+  expect_error(
+    epi_calendar(as.Date("2023-01-15"), start = 30, end = 40),
+    "`start` must be greater than `end`!"
   )
-  expect_equal(
-    epi_calendar(as.Date("2023-12-01"), start = 3, end = 20), "out_of_season"
+  expect_error(
+    epi_calendar(as.Date("2023-12-01"), start = 3, end = 20),
+    "`start` must be greater than `end`!"
   )
 })
 

--- a/tests/testthat/test-epi_calendar.R
+++ b/tests/testthat/test-epi_calendar.R
@@ -32,8 +32,8 @@ test_that("All dates from week 53 belongs to correct season 2015/2016", {
   week_53_season_15_16 <- c("2015-12-28", "2015-12-29", "2015-12-30",
                             "2015-12-31", "2016-01-01", "2016-01-02",
                             "2016-01-03")
-  results <- map(week_53_season_15_16,
-                 ~ epi_calendar(as.Date(.x), start = 21, end = 20))
+  results <- purrr::map(week_53_season_15_16,
+                        ~ epi_calendar(as.Date(.x), start = 21, end = 20))
   results_vector <- unlist(results)
 
   expect_equal(results_vector, rep("2015/2016", length(week_53_season_15_16)))

--- a/tests/testthat/test-epi_calendar.R
+++ b/tests/testthat/test-epi_calendar.R
@@ -1,16 +1,16 @@
 # Test if a date within the season returns the correct season
 test_that("Within the season, correct season is returned", {
   expect_equal(
-    epi_calendar(as.Date("2023-03-15"), start = 40, end = 20), "2022/2023"
+    epi_calendar(as.Date("2023-03-15"), start = 21, end = 20), "2022/2023"
   )
   expect_equal(
-    epi_calendar(as.Date("2023-05-01"), start = 40, end = 20), "2022/2023"
+    epi_calendar(as.Date("2023-05-01"), start = 21, end = 20), "2022/2023"
   )
   expect_equal(
-    epi_calendar(as.Date("2023-01-15"), start = 40, end = 20), "2022/2023"
+    epi_calendar(as.Date("2023-01-15"), start = 21, end = 20), "2022/2023"
   )
   expect_equal(
-    epi_calendar(as.Date("2023-12-01"), start = 40, end = 20), "2023/2024"
+    epi_calendar(as.Date("2023-12-01"), start = 21, end = 20), "2023/2024"
   )
 })
 
@@ -25,4 +25,16 @@ test_that("Outside the season, 'out_of_season' is returned", {
   expect_equal(
     epi_calendar(as.Date("2023-06-30"), start = 40, end = 20), "out_of_season"
   )
+})
+
+# Test that all dates from week 53 belongs to correct season 2015/2016
+test_that("All dates from week 53 belongs to correct season 2015/2016", {
+  week_53_season_15_16 <- c("2015-12-28", "2015-12-29", "2015-12-30",
+                            "2015-12-31", "2016-01-01", "2016-01-02",
+                            "2016-01-03")
+  results <- map(week_53_season_15_16,
+                 ~ epi_calendar(as.Date(.x), start = 21, end = 20))
+  results_vector <- unlist(results)
+
+  expect_equal(results_vector, rep("2015/2016", length(week_53_season_15_16)))
 })

--- a/tests/testthat/test-epi_calendar.R
+++ b/tests/testthat/test-epi_calendar.R
@@ -43,6 +43,16 @@ test_that("Within one year, out_of_season is returned", {
   )
 })
 
+# Test that boundary weeks are included if end < start
+test_that("Within the season, boundary weeks are included if end < start", {
+  expect_equal(
+    epi_calendar(as.Date("2023-03-15"), start = 40, end = 11), "2022/2023"
+  )
+  expect_equal(
+    epi_calendar(as.Date("2024-09-30"), start = 40, end = 11), "2024/2025"
+  )
+})
+
 # Test that all dates from week 53 belongs to correct season 2015/2016
 test_that("All dates from week 53 belongs to correct season 2015/2016", {
   week_53_season_15_16 <- c("2015-12-28", "2015-12-29", "2015-12-30",

--- a/tests/testthat/test-epi_calendar.R
+++ b/tests/testthat/test-epi_calendar.R
@@ -27,6 +27,22 @@ test_that("Outside the season, 'out_of_season' is returned", {
   )
 })
 
+# Test if algorithm returns out_of_season when start:end only spand one year
+test_that("Within one year, out_of_season is returned", {
+  expect_equal(
+    epi_calendar(as.Date("2023-03-15"), start = 2, end = 5), "out_of_season"
+  )
+  expect_equal(
+    epi_calendar(as.Date("2023-05-01"), start = 1, end = 53), "out_of_season"
+  )
+  expect_equal(
+    epi_calendar(as.Date("2023-01-15"), start = 30, end = 40), "out_of_season"
+  )
+  expect_equal(
+    epi_calendar(as.Date("2023-12-01"), start = 3, end = 20), "out_of_season"
+  )
+})
+
 # Test that all dates from week 53 belongs to correct season 2015/2016
 test_that("All dates from week 53 belongs to correct season 2015/2016", {
   week_53_season_15_16 <- c("2015-12-28", "2015-12-29", "2015-12-30",


### PR DESCRIPTION
**Currently the ISO week daye system is not correctly implemented in epi_calender function.**
%U: The week number (00–53) of the year (Sunday as the first day of the week).
%V: The ISO 8601 week number (01–53), where Monday is considered the first day of the week. The first week of the year is defined as the week containing the first Thursday of the year.
%Y: Year with century.
%G: The week-based year (see %V) as a decimal number.

Following function is changed to use the ISO numbering with "%V":
```
current_week <- as.integer(format(x = date, "%U")) ->
current_week <- as.integer(format(x = date, "%V"))
```
The year function does not use ISO either:
current_year <- format(date, "%Y")
meaning that fx date 2018-12-31 will be placed in season 2017/2018 instead of 2018/2019:
```
 ISOweek(as.Date("2018-12-31"))
[1] "2019-W01"
> epi_calendar(date = as.Date("2018-12-31"), start = 21, end = 20)
[1] "Year 2018"
[1] "Season 2017/2018"
```
Wil be changed to:
```
current_year <- as.integer(strftime(date, format = "%G"))
```
This approach correctly captures the ISO year, and ensures alignemnt with the ISO week date system.

**Season has been added to the adseo function**
- the season can be given as season = c(start,end) which is the start and end week of the season.
- the function then uses epi_calendar to calculate which season the observations belong to.
- Seasons have to spand two years.

**Summary now also shows which time interval the observations have.**
- Summary shows which seasons are included in the tsd. -> if the user did not select seasons then it will just state "Not defined".

This PR builds on following PR which needs to be merged before this PR is ready
* [x] #33

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
