### PR TITLE
Add possibility to get results for all seasons or only current season

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-* Added a new argument `only_current_season` to `seasonal_onset()`, `seasonal_burden_levels()` and `combined_seasonal_output()` which gives the possibility to either get output from only the current season or for all available seasons.
+* Added a new argument `only_current_season` to `seasonal_onset()`, `seasonal_burden_levels()` and `combined_seasonal_output()` which gives the possibility to either get output from only the current season or for all available seasons (#45).
 
 * Added `combined_seasonal_output()` as the main function to run both `seasonal_onset()` and `seasonal_burden_levels()` to get a combined result for the newest season (#44).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## Features
 
+* Added a new argument `only_current_season` to `seasonal_onset()`, `seasonal_burden_levels()` and `combined_seasonal_output()` which gives the possibility to either get output from only the current season or for all available seasons.
+
 * Added `combined_seasonal_output()` as the main function to run both `seasonal_onset()` and `seasonal_burden_levels()` to get a combined result for the newest season (#44).
 
 * Added `seasonal_onset()` as a replacement for the deprecated `aedseo()` function (#41).

--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -19,13 +19,13 @@ rd_family <- function(usage = NULL) {
   paste("A character string specifying the family for modeling",
         ifelse(usage == "combined", paste(" seasonal onset.")))
 }
+rd_only_current_season <- "A logical determining if the output should only include results for current season (TRUE) or
+if the output should include results for all previous seasons"
 rd_season_weeks <- function(usage = NULL) {
   paste("A numeric vector of length 2, `c(start,end)`, with the start and end weeks of the seasons to
   stratify the observations by. Must span the new year; ex: `season_weeks = c(21, 20)`.",
         ifelse(usage == "onset", paste("If set to `NULL`, is  means no stratification by season.")))
 }
-rd_tsd <- "An object containing time series data with 'time' and 'observation.'"
-
 rd_seasonal_onset_return <- paste(
   "\nA `seasonal_onset` object containing:\n",
   "- 'reference_time': The time point for which the growth rate is estimated.\n",
@@ -41,7 +41,6 @@ rd_seasonal_onset_return <- paste(
   "- 'skipped_window': Logical. Was the window skipped due to missing?\n",
   "- 'converged': Logical. Was the IWLS judged to have converged?"
 )
-
 rd_seasonal_burden_levels_return <- paste(
   "\nA list containing:\n",
   "- 'season': The season that burden levels are calculated for.\n",
@@ -66,3 +65,4 @@ rd_seasonal_burden_levels_return <- paste(
   "   - 'exp': Uses the Exponential distribution for fitting.\n",
   "   - 'disease_threshold': The input disease threshold, which is also the very low level."
 )
+rd_tsd <- "An object containing time series data with 'time' and 'observation.'"

--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -19,8 +19,7 @@ rd_family <- function(usage = NULL) {
   paste("A character string specifying the family for modeling",
         ifelse(usage == "combined", paste(" seasonal onset.")))
 }
-rd_only_current_season <- "A logical determining if the output should only include results for the current season (TRUE)
-or if the output should include results for all available seasons (FALSE)"
+rd_only_current_season <- "Should the output only include results for the current season?"
 rd_season_weeks <- function(usage = NULL) {
   paste("A numeric vector of length 2, `c(start,end)`, with the start and end weeks of the seasons to
   stratify the observations by. Must span the new year; ex: `season_weeks = c(21, 20)`.",

--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -19,8 +19,8 @@ rd_family <- function(usage = NULL) {
   paste("A character string specifying the family for modeling",
         ifelse(usage == "combined", paste(" seasonal onset.")))
 }
-rd_only_current_season <- "A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons (FALSE)"
+rd_only_current_season <- "A logical determining if the output should only include results for the current season (TRUE)
+or if the output should include results for all available seasons (FALSE)"
 rd_season_weeks <- function(usage = NULL) {
   paste("A numeric vector of length 2, `c(start,end)`, with the start and end weeks of the seasons to
   stratify the observations by. Must span the new year; ex: `season_weeks = c(21, 20)`.",

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -96,13 +96,14 @@ combined_seasonal_output <- function(
                                  family = family, na_fraction_allowed = na_fraction_allowed,
                                  season_weeks = season_weeks, only_current_season)
 
-  # Extract current season from onset_output and create seasonal_onset
+  # Extract seasons from onset_output and create seasonal_onset
   onset_output <- onset_output |>
     dplyr::group_by(.data$season) |>
     dplyr::mutate(onset_flag = cumsum(.data$seasonal_onset_alarm),
                   seasonal_onset = .data$onset_flag == 1 & !duplicated(.data$onset_flag)) |>
     dplyr::select(-(.data$onset_flag))
 
+  # Extract only current season if assigned
   if (only_current_season == TRUE) {
     onset_output <- onset_output |>
       dplyr::filter(.data$season == max(.data$season))

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -90,11 +90,11 @@ combined_seasonal_output <- function(
   burden_output <- seasonal_burden_levels(tsd = tsd, season_weeks = season_weeks, method = method,
                                           conf_levels = conf_levels, decay_factor = decay_factor,
                                           disease_threshold = disease_threshold, n_peak = n_peak,
-                                          family = family_quant, only_current_season, ...)
+                                          family = family_quant, only_current_season = only_current_season, ...)
 
   onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,
                                  family = family, na_fraction_allowed = na_fraction_allowed,
-                                 season_weeks = season_weeks, only_current_season)
+                                 season_weeks = season_weeks, only_current_season = only_current_season)
 
   # Extract seasons from onset_output and create seasonal_onset
   onset_output <- onset_output |>

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -83,24 +83,30 @@ combined_seasonal_output <- function(
   conf_levels = 0.95,
   decay_factor = 0.8,
   n_peak = 6,
+  only_current_season = TRUE,
   ...
 ) {
   # Run the models
   burden_output <- seasonal_burden_levels(tsd = tsd, season_weeks = season_weeks, method = method,
                                           conf_levels = conf_levels, decay_factor = decay_factor,
                                           disease_threshold = disease_threshold, n_peak = n_peak,
-                                          family = family_quant, ...)
+                                          family = family_quant, only_current_season, ...)
 
   onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,
                                  family = family, na_fraction_allowed = na_fraction_allowed,
-                                 season_weeks = season_weeks)
+                                 season_weeks = season_weeks, only_current_season)
 
   # Extract current season from onset_output and create seasonal_onset
   onset_output <- onset_output |>
-    dplyr::filter(.data$season == max(.data$season)) |>
+    dplyr::group_by(.data$season) |>
     dplyr::mutate(onset_flag = cumsum(.data$seasonal_onset_alarm),
                   seasonal_onset = .data$onset_flag == 1 & !duplicated(.data$onset_flag)) |>
     dplyr::select(-(.data$onset_flag))
+
+  if (only_current_season == TRUE) {
+    onset_output <- onset_output |>
+      dplyr::filter(.data$season == max(.data$season))
+  }
 
   return(list(onset_output = onset_output, burden_output = burden_output))
 }

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -28,6 +28,7 @@
 #' @param disease_threshold `r rd_disease_threshold(usage = "levels")`
 #' @param n_peak A numeric value specifying the number of peak observations to be selected from each season in the
 #' level calculations. The `n_peak` observations have to surpass the `disease_threshold` to be included.
+#' @param only_current_season `r rd_only_current_season`
 #' @param ... Arguments passed to the `fit_quantiles()` function.
 #'
 #' @return `r rd_seasonal_burden_levels_return`
@@ -135,7 +136,7 @@ seasonal_burden_levels <- function(
       peak_levels = {
         model_output <- append(quantiles_fit, list(season = max(seasonal_tsd$season)), after = 0)
         model_output$values <- stats::setNames(c(disease_threshold, model_output$values),
-                                              c("very low", "low", "medium", "high"))
+                                               c("very low", "low", "medium", "high"))
         model_output <- append(model_output, list(disease_threshold = disease_threshold))
       },
       intensity_levels = {

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -159,11 +159,10 @@ seasonal_burden_levels <- function(
   if (only_current_season == FALSE) {
     # Group seasons to get results for all seasons available
     unique_seasons <- unique(rev(peak_seasonal_tsd$season))
-    season_groups <- purrr::map(seq_along(unique_seasons), ~ unique_seasons[1:.x]) |>
-      purrr::accumulate(union)
+    season_groups <- purrr::accumulate(unique_seasons, `c`)
     season_groups_data <- purrr::map(season_groups[-1], ~ peak_seasonal_tsd |> dplyr::filter(.data$season %in% .x))
 
-    level_results <- purrr::map(season_groups_data, ~ main_level_fun(.x))
+    level_results <- purrr::map(season_groups_data, main_level_fun)
 
   } else {
     level_results <- main_level_fun(peak_seasonal_tsd)

--- a/R/seasonal_onset.R
+++ b/R/seasonal_onset.R
@@ -13,7 +13,7 @@
 #' @param na_fraction_allowed Numeric value between 0 and 1 specifying the fraction of observables in the window
 #' of size k that are allowed to be NA in onset calculations.
 #' @param season_weeks `r rd_season_weeks(usage = "onset")`
-#' @param only_current_season blabla
+#' @param only_current_season `r rd_only_current_season`
 #'
 #' @return `r rd_seasonal_onset_return`
 #'
@@ -73,6 +73,9 @@ seasonal_onset <- function(
   if (is.null(season_weeks) && !is.null(only_current_season)) {
     coll$push("If season_weeks is NULL only_current_season must also be NULL")
   }
+  if (!is.null(season_weeks) && is.null(only_current_season)) {
+    coll$push("If season_weeks is assigned only_current_season must also be assigned")
+  }
   checkmate::reportAssertions(coll)
 
   # Throw an error if any of the inputs are not supported
@@ -83,10 +86,6 @@ seasonal_onset <- function(
     tsd <- tsd |> dplyr::mutate(season = epi_calendar(.data$time))
   } else {
     tsd <- tsd |> dplyr::mutate(season = "not_defined")
-  }
-
-  if (!is.null(season_weeks) && only_current_season == TRUE) {
-    tsd <- tsd |> dplyr::filter(.data$season == max(.data$season))
   }
 
   # Extract the length of the series
@@ -156,6 +155,11 @@ seasonal_onset <- function(
     disease_threshold = disease_threshold,
     family = family
   )
+
+  # Extract only current season if assigned
+  if (!is.null(season_weeks) && only_current_season == TRUE) {
+    ans <- ans |> dplyr::filter(.data$season == max(.data$season))
+  }
 
   # Keep attributes from the `tsd` class
   attr(ans, "time_interval") <- attr(tsd, "time_interval")

--- a/R/seasonal_onset.R
+++ b/R/seasonal_onset.R
@@ -13,6 +13,7 @@
 #' @param na_fraction_allowed Numeric value between 0 and 1 specifying the fraction of observables in the window
 #' of size k that are allowed to be NA in onset calculations.
 #' @param season_weeks `r rd_season_weeks(usage = "onset")`
+#' @param only_current_season blabla
 #'
 #' @return `r rd_seasonal_onset_return`
 #'
@@ -54,7 +55,8 @@ seasonal_onset <- function(
       # TODO: #10 Include negative.binomial regressions. @telkamp7
     ),
     na_fraction_allowed = 0.4,
-    season_weeks = NULL) {
+    season_weeks = NULL,
+    only_current_season = NULL) {
   # Check input arguments
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_data_frame(tsd, add = coll)
@@ -67,17 +69,14 @@ seasonal_onset <- function(
   checkmate::assert_integerish(disease_threshold, add = coll)
   checkmate::assert_integerish(season_weeks, len = 2, lower = 1, upper = 53,
                                null.ok = TRUE, add = coll)
+  checkmate::assert_logical(only_current_season, null.ok = TRUE, add = coll)
+  if (is.null(season_weeks) && !is.null(only_current_season)) {
+    coll$push("If season_weeks is NULL only_current_season must also be NULL")
+  }
   checkmate::reportAssertions(coll)
 
   # Throw an error if any of the inputs are not supported
   family <- rlang::arg_match(family)
-
-  # Extract the length of the series
-  n <- base::nrow(tsd)
-
-  # Allocate space for growth rate estimates
-  res <- tibble::tibble()
-  skipped_window <- base::rep(FALSE, base::nrow(tsd))
 
   # Add the seasons to tsd if available
   if (!is.null(season_weeks)) {
@@ -85,6 +84,17 @@ seasonal_onset <- function(
   } else {
     tsd <- tsd |> dplyr::mutate(season = "not_defined")
   }
+
+  if (!is.null(season_weeks) && only_current_season == TRUE) {
+    tsd <- tsd |> dplyr::filter(.data$season == max(.data$season))
+  }
+
+  # Extract the length of the series
+  n <- base::nrow(tsd)
+
+  # Allocate space for growth rate estimates
+  res <- tibble::tibble()
+  skipped_window <- base::rep(FALSE, base::nrow(tsd))
 
   for (i in k:n) {
     # Index observations for this iteration

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -70,8 +70,7 @@ the influence of older seasons diminishes exponentially.}
 \item{n_peak}{A numeric value specifying the number of peak observations to be selected from each season in the
 level calculations. The \code{n_peak} observations have to surpass the \code{disease_threshold} to be included.}
 
-\item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons (FALSE)}
+\item{only_current_season}{Should the output only include results for the current season?}
 
 \item{...}{Arguments passed to the \code{fit_quantiles()} function in the burden level calculations.}
 }

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -17,6 +17,7 @@ combined_seasonal_output(
   conf_levels = 0.95,
   decay_factor = 0.8,
   n_peak = 6,
+  only_current_season = TRUE,
   ...
 )
 }

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -71,7 +71,7 @@ the influence of older seasons diminishes exponentially.}
 level calculations. The \code{n_peak} observations have to surpass the \code{disease_threshold} to be included.}
 
 \item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons}
+if the output should include results for all previous seasons (FALSE)}
 
 \item{...}{Arguments passed to the \code{fit_quantiles()} function in the burden level calculations.}
 }

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -51,8 +51,7 @@ included in the level calculations.}
 \item{n_peak}{A numeric value specifying the number of peak observations to be selected from each season in the
 level calculations. The \code{n_peak} observations have to surpass the \code{disease_threshold} to be included.}
 
-\item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons (FALSE)}
+\item{only_current_season}{Should the output only include results for the current season?}
 
 \item{...}{Arguments passed to the \code{fit_quantiles()} function.}
 }

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -52,7 +52,7 @@ included in the level calculations.}
 level calculations. The \code{n_peak} observations have to surpass the \code{disease_threshold} to be included.}
 
 \item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons}
+if the output should include results for all previous seasons (FALSE)}
 
 \item{...}{Arguments passed to the \code{fit_quantiles()} function.}
 }

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -12,6 +12,7 @@ seasonal_burden_levels(
   decay_factor = 0.8,
   disease_threshold = 20,
   n_peak = 6,
+  only_current_season = TRUE,
   ...
 )
 }

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -11,7 +11,8 @@ seasonal_onset(
   disease_threshold = NA_integer_,
   family = c("poisson", "quasipoisson"),
   na_fraction_allowed = 0.4,
-  season_weeks = NULL
+  season_weeks = NULL,
+  only_current_season = NULL
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ of size k that are allowed to be NA in onset calculations.}
 
 \item{season_weeks}{A numeric vector of length 2, \code{c(start,end)}, with the start and end weeks of the seasons to
 stratify the observations by. Must span the new year; ex: \code{season_weeks = c(21, 20)}. If set to \code{NULL}, is  means no stratification by season.}
+
+\item{only_current_season}{blabla}
 }
 \value{
 A \code{seasonal_onset} object containing:

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -34,8 +34,7 @@ of size k that are allowed to be NA in onset calculations.}
 \item{season_weeks}{A numeric vector of length 2, \code{c(start,end)}, with the start and end weeks of the seasons to
 stratify the observations by. Must span the new year; ex: \code{season_weeks = c(21, 20)}. If set to \code{NULL}, is  means no stratification by season.}
 
-\item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons (FALSE)}
+\item{only_current_season}{Should the output only include results for the current season?}
 }
 \value{
 A \code{seasonal_onset} object containing:

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -35,7 +35,7 @@ of size k that are allowed to be NA in onset calculations.}
 stratify the observations by. Must span the new year; ex: \code{season_weeks = c(21, 20)}. If set to \code{NULL}, is  means no stratification by season.}
 
 \item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or
-if the output should include results for all previous seasons}
+if the output should include results for all previous seasons (FALSE)}
 }
 \value{
 A \code{seasonal_onset} object containing:

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -35,7 +35,7 @@ of size k that are allowed to be NA in onset calculations.}
 stratify the observations by. Must span the new year; ex: \code{season_weeks = c(21, 20)}. If set to \code{NULL}, is  means no stratification by season.}
 
 \item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or if the output
-should include results for all previous seasons}
+should include results for all previous seasons (FALSE)}
 }
 \value{
 A \code{seasonal_onset} object containing:

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -34,7 +34,8 @@ of size k that are allowed to be NA in onset calculations.}
 \item{season_weeks}{A numeric vector of length 2, \code{c(start,end)}, with the start and end weeks of the seasons to
 stratify the observations by. Must span the new year; ex: \code{season_weeks = c(21, 20)}. If set to \code{NULL}, is  means no stratification by season.}
 
-\item{only_current_season}{blabla}
+\item{only_current_season}{A logical determining if the output should only include results for current season (TRUE) or if the output
+should include results for all previous seasons}
 }
 \value{
 A \code{seasonal_onset} object containing:

--- a/tests/testthat/test-combined_seasonal_output.R
+++ b/tests/testthat/test-combined_seasonal_output.R
@@ -1,5 +1,4 @@
-test_that("Output only includes one season", {
-
+test_that("Test that selection of current and all seasons work as expected", {
   start_date <- as.Date("2021-01-04")
   end_date <- as.Date("2023-12-31")
 
@@ -15,8 +14,36 @@ test_that("Output only includes one season", {
     time_interval = "week"
   )
 
-  combined_df <- combined_seasonal_output(tsd = tsd_data)
+  current_season <- epi_calendar(end_date)
 
-  expect_equal(length(unique(combined_df$onset_output$season)), 1)
-  expect_equal(length(combined_df$burden_output$season), 1)
+  current_season_output <- combined_seasonal_output(tsd_data, only_current_season = TRUE)
+  all_seasons_output <- combined_seasonal_output(tsd_data, only_current_season = FALSE)
+
+  expect_equal(unique(current_season_output$onset_output$season), current_season)
+  expect_equal(unique(current_season_output$burden_output$season), current_season)
+
+  expect_gt(length(unique(all_seasons_output$onset_output$season)), length(current_season))
+  expect_gt(length(all_seasons_output$burden_output), length(current_season))
+})
+
+test_that("Test that onset_output has one more season than burden_output", {
+  start_date <- as.Date("2021-01-04")
+  end_date <- as.Date("2023-12-31")
+
+  weekly_dates <- seq.Date(from = start_date,
+                           to = end_date,
+                           by = "week")
+
+  obs <- stats::rpois(length(weekly_dates), 1000)
+
+  tsd_data <- to_time_series(
+    observation = obs,
+    time = as.Date(weekly_dates),
+    time_interval = "week"
+  )
+
+  all_seasons_output <- combined_seasonal_output(tsd_data, only_current_season = FALSE)
+
+  expect_equal(length(unique(all_seasons_output$onset_output$season)), 4)
+  expect_equal(length(all_seasons_output$burden_output), 3)
 })

--- a/tests/testthat/test-combined_seasonal_output.R
+++ b/tests/testthat/test-combined_seasonal_output.R
@@ -22,8 +22,8 @@ test_that("Test that selection of current and all seasons work as expected", {
   expect_equal(unique(current_season_output$onset_output$season), current_season)
   expect_equal(unique(current_season_output$burden_output$season), current_season)
 
-  expect_gt(length(unique(all_seasons_output$onset_output$season)), length(current_season))
-  expect_gt(length(all_seasons_output$burden_output), length(current_season))
+  expect_gt(length(unique(all_seasons_output$onset_output$season)), 1)
+  expect_gt(length(all_seasons_output$burden_output), 1)
 })
 
 test_that("Test that onset_output has one more season than burden_output", {
@@ -44,6 +44,6 @@ test_that("Test that onset_output has one more season than burden_output", {
 
   all_seasons_output <- combined_seasonal_output(tsd_data, only_current_season = FALSE)
 
-  expect_equal(length(unique(all_seasons_output$onset_output$season)), 4)
-  expect_equal(length(all_seasons_output$burden_output), 3)
+  expect_length(unique(all_seasons_output$onset_output$season), 4)
+  expect_length(all_seasons_output$burden_output, 3)
 })

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -141,3 +141,28 @@ test_that("Test that function fail with less than two seasons", {
     )
   )
 })
+
+test_that("Test that selection of current and all seasons work as expected", {
+  start_date <- as.Date("2021-01-04")
+  end_date <- as.Date("2023-12-31")
+
+  weekly_dates <- seq.Date(from = start_date,
+                           to = end_date,
+                           by = "week")
+
+  obs <- stats::rpois(length(weekly_dates), 1000)
+
+  tsd_data <- to_time_series(
+    observation = obs,
+    time = as.Date(weekly_dates),
+    time_interval = "week"
+  )
+
+  current_season <- epi_calendar(end_date)
+
+  current_level <- seasonal_burden_levels(tsd_data, only_current_season = TRUE)
+  all_levels <- seasonal_burden_levels(tsd_data, only_current_season = FALSE)
+
+  expect_equal(current_season, unique(current_level$season))
+  expect_gt(length(all_levels), length(current_season))
+})

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -164,5 +164,5 @@ test_that("Test that selection of current and all seasons work as expected", {
   all_levels <- seasonal_burden_levels(tsd_data, only_current_season = FALSE)
 
   expect_equal(current_season, unique(current_level$season))
-  expect_gt(length(all_levels), length(current_season))
+  expect_gt(length(all_levels), 1)
 })

--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -149,22 +149,25 @@ test_that("Test that input argument checks work", {
 
 })
 
+test_that("Test that selection of current season work as expected", {
+  start_date <- as.Date("2021-01-04")
+  end_date <- as.Date("2023-12-31")
 
-start_date <- as.Date("2021-01-04")
-end_date <- as.Date("2023-12-31")
+  weekly_dates <- seq.Date(from = start_date,
+                           to = end_date,
+                           by = "week")
 
-weekly_dates <- seq.Date(from = start_date,
-                         to = end_date,
-                         by = "week")
+  obs <- stats::rpois(length(weekly_dates), 1000)
 
-obs <- stats::rpois(length(weekly_dates), 1000)
+  tsd_data <- to_time_series(
+    observation = obs,
+    time = as.Date(weekly_dates),
+    time_interval = "week"
+  )
 
-tsd_data <- to_time_series(
-  observation = obs,
-  time = as.Date(weekly_dates),
-  time_interval = "week"
-)
+  current_season <- epi_calendar(end_date)
 
-test <- seasonal_onset(tsd_data, season_weeks = c(20,21), only_current_season = TRUE)
+  current_onset <- seasonal_onset(tsd_data, season_weeks = c(20, 21), only_current_season = TRUE)
 
-
+  expect_equal(current_season, unique(current_onset$season))
+})

--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -149,7 +149,7 @@ test_that("Test that input argument checks work", {
 
 })
 
-test_that("Test that selection of current season work as expected", {
+test_that("Test that selection of current and all seasons work as expected", {
   start_date <- as.Date("2021-01-04")
   end_date <- as.Date("2023-12-31")
 
@@ -168,6 +168,8 @@ test_that("Test that selection of current season work as expected", {
   current_season <- epi_calendar(end_date)
 
   current_onset <- seasonal_onset(tsd_data, season_weeks = c(20, 21), only_current_season = TRUE)
+  all_onsets <- seasonal_onset(tsd_data, season_weeks = c(20, 21), only_current_season = FALSE)
 
   expect_equal(current_season, unique(current_onset$season))
+  expect_gt(length(unique(all_onsets$season)), length(current_season))
 })

--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -171,5 +171,5 @@ test_that("Test that selection of current and all seasons work as expected", {
   all_onsets <- seasonal_onset(tsd_data, season_weeks = c(20, 21), only_current_season = FALSE)
 
   expect_equal(current_season, unique(current_onset$season))
-  expect_gt(length(unique(all_onsets$season)), length(current_season))
+  expect_gt(length(unique(all_onsets$season)), 1)
 })

--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -148,3 +148,23 @@ test_that("Test that input argument checks work", {
   expect_error(seasonal_onset(tsd_data))
 
 })
+
+
+start_date <- as.Date("2021-01-04")
+end_date <- as.Date("2023-12-31")
+
+weekly_dates <- seq.Date(from = start_date,
+                         to = end_date,
+                         by = "week")
+
+obs <- stats::rpois(length(weekly_dates), 1000)
+
+tsd_data <- to_time_series(
+  observation = obs,
+  time = as.Date(weekly_dates),
+  time_interval = "week"
+)
+
+test <- seasonal_onset(tsd_data, season_weeks = c(20,21), only_current_season = TRUE)
+
+


### PR DESCRIPTION
This PR adds the `only_current_season` argument to `seasonal_onset()`, `seasonal_burden_levels()` and `combined_seasonal_output()`. The argument lets the user decide if they want the results to include all seasons available in the data or only the current season.

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR