### PR TITLE
Minor error fix

### DIFF
--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -146,7 +146,7 @@ seasonal_burden_levels <- function(
           high_conf_level = quantiles_fit$conf_levels,
           values = stats::setNames(level_step_log, c("very low", "low", "medium", "high")),
           par = quantiles_fit$par,
-          obj_value = quantiles_fit$conf_levels,
+          obj_value = quantiles_fit$obj_value,
           converged = quantiles_fit$converged,
           family = quantiles_fit$family,
           disease_threshold = disease_threshold


### PR DESCRIPTION
This PR fixes a typing error that returned the `obj_value` as the `conf_levels` instead of as the correct `obj_value` from the optimiser.

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR