### PR TITLE
Fixing error if current season does not surpass disease_threshold

### DIFF
--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -118,13 +118,8 @@ seasonal_burden_levels <- function(
   main_level_fun <- function(seasonal_tsd, current_season) {
 
     # Add weights and remove current season to get predictions for this season
-    if (current_season %in% unique(seasonal_tsd$season)) {
-      previous_tsd <- seasonal_tsd |>
-        dplyr::filter(.data$season != max(.data$season))
-    } else {
-      previous_tsd <- seasonal_tsd
-    }
-    weighted_seasonal_tsd <- previous_tsd |>
+    weighted_seasonal_tsd <- seasonal_tsd |>
+      dplyr::filter(.data$season != current_season) |>
       dplyr::mutate(year = purrr::map_chr(.data$season, ~ stringr::str_extract(.x, "[0-9]+")) |>
                       as.numeric()) |>
       dplyr::mutate(weight = decay_factor^(max(.data$year) - .data$year)) |>
@@ -162,7 +157,7 @@ seasonal_burden_levels <- function(
     return(results)
   }
   # Select seasons for output based on only_current_season input argument
-  current_season <- unique(seasonal_tsd$season)[1]
+  current_season <- max(seasonal_tsd$season)
 
   if (only_current_season == FALSE) {
     # Group seasons to get results for all seasons available

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -166,3 +166,34 @@ test_that("Test that selection of current and all seasons work as expected", {
   expect_equal(current_season, unique(current_level$season))
   expect_gt(length(all_levels), 1)
 })
+
+
+test_that("Test that function does not fail if there are no observations surpassing the disease specific threshold
+          in the current season.", {
+            start_date <- as.Date("2022-05-23")
+            end_date <- as.Date("2023-05-15")
+
+            start_date_2 <- as.Date("2023-05-22")
+            end_date_2 <- as.Date("2024-05-13")
+
+            weekly_dates <- seq.Date(from = start_date,
+                                     to = end_date,
+                                     by = "week")
+
+            weekly_dates_2 <- seq.Date(from = start_date_2,
+                                       to = end_date_2,
+                                       by = "week")
+
+            obs <- stats::rpois(length(weekly_dates), 1000)
+            obs_2 <- stats::rpois(length(weekly_dates), 10)
+
+            tsd_data <- to_time_series(
+              observation = c(obs, obs_2),
+              time = c(as.Date(weekly_dates), as.Date(weekly_dates_2)),
+              time_interval = "week"
+            )
+
+            burden_list <- seasonal_burden_levels(tsd_data, disease_threshold = 100)
+
+            expect_equal(burden_list$season, "2023/2024")
+          })


### PR DESCRIPTION
`seasonal_burden_levels()` failed if no observations in the current season did surpass the disease specific threshold. This was due to using this season as the naming for the output (if no observations surpassed then the season was not included in the data). Now the current season is always passed to the `main_level_fun()` and removed from the data if present (as before), but is still used as naming for the output. 

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR