### PR TITLE
Fixing season in seasonal_burden_levels

### DIFF
--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -93,7 +93,7 @@ combined_seasonal_output <- function(
                                           disease_threshold = disease_threshold, n_peak = n_peak,
                                           family = family_quant, only_current_season = only_current_season, ...)
 
-  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,       # nolint: lintrobject_usage_linter
+  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,       # nolint: object_usage_linter.
                                  family = family, na_fraction_allowed = na_fraction_allowed,
                                  season_start = season_start, season_end = season_end,
                                  only_current_season = only_current_season)

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -93,10 +93,10 @@ combined_seasonal_output <- function(
                                           disease_threshold = disease_threshold, n_peak = n_peak,
                                           family = family_quant, only_current_season = only_current_season, ...)
 
-  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,       # nolint: object_usage_linter.
+  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,
                                  family = family, na_fraction_allowed = na_fraction_allowed,
                                  season_start = season_start, season_end = season_end,
-                                 only_current_season = only_current_season)
+                                 only_current_season = only_current_season)             # nolint: object_usage_linter.
 
   # Extract seasons from onset_output and create seasonal_onset
   onset_output <- onset_output |>

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -93,7 +93,7 @@ combined_seasonal_output <- function(
                                           disease_threshold = disease_threshold, n_peak = n_peak,
                                           family = family_quant, only_current_season = only_current_season, ...)
 
-  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,
+  onset_output <- seasonal_onset(tsd = tsd, k = k, level = level, disease_threshold = disease_threshold,       # nolint: lintrobject_usage_linter
                                  family = family, na_fraction_allowed = na_fraction_allowed,
                                  season_start = season_start, season_end = season_end,
                                  only_current_season = only_current_season)

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -124,7 +124,6 @@ seasonal_burden_levels <- function(
 
   # main level function
   main_level_fun <- function(seasonal_tsd, current_season) {
-
     # Add weights and remove current season to get predictions for this season
     weighted_seasonal_tsd <- seasonal_tsd |>
       dplyr::filter(.data$season != current_season) |>
@@ -165,18 +164,16 @@ seasonal_burden_levels <- function(
     return(results)
   }
   # Select seasons for output based on only_current_season input argument
-  current_season <- max(seasonal_tsd$season)
-
   if (only_current_season == FALSE) {
     # Group seasons to get results for all seasons available
     unique_seasons <- unique(rev(peak_seasonal_tsd$season))
     season_groups <- purrr::accumulate(unique_seasons, `c`)
     season_groups_data <- purrr::map(season_groups[-1], ~ peak_seasonal_tsd |> dplyr::filter(.data$season %in% .x))
 
-    level_results <- purrr::map(season_groups_data, ~ main_level_fun(.x, current_season))
+    level_results <- purrr::map(season_groups_data, ~ main_level_fun(.x, current_season = max(.x$season)))
 
   } else {
-    level_results <- main_level_fun(peak_seasonal_tsd, current_season)
+    level_results <- main_level_fun(peak_seasonal_tsd, current_season = max(seasonal_tsd$season))
   }
   return(level_results)
 }

--- a/R/seasonal_onset.R
+++ b/R/seasonal_onset.R
@@ -42,7 +42,9 @@
 #'   disease_threshold = 20,
 #'   family = "poisson",
 #'   na_fraction_allowed = 0.4,
-#'   season_start = NULL
+#'   season_start = NULL,
+#'   season_end = NULL,
+#'   only_current_season = NULL
 #' )
 seasonal_onset <- function(                                     # nolint: cyclocomp_linter.
     tsd,

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -81,6 +81,8 @@ seasonal_onset(
   disease_threshold = 20,
   family = "poisson",
   na_fraction_allowed = 0.4,
-  season_start = NULL
+  season_start = NULL,
+  season_end = NULL,
+  only_current_season = NULL
 )
 }

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -207,3 +207,33 @@ test_that("Test that function does not fail if there are no observations surpass
 
             expect_equal(burden_list$season, "2023/2024")
           })
+
+test_that("Test that seasons are correctly increasing when only_current_season = FALSE", {
+  start_date <- as.Date("2021-01-04")
+  end_date <- as.Date("2023-12-31")
+
+  weekly_dates <- seq.Date(from = start_date,
+                           to = end_date,
+                           by = "week")
+
+  set.seed(123)
+  obs <- stats::rpois(length(weekly_dates), 1000)
+
+  tsd_data <- to_time_series(
+    observation = obs,
+    time = as.Date(weekly_dates),
+    time_interval = "week"
+  )
+
+  seasons <- seasonal_onset(tsd = tsd_data,
+                            season_start = 21,
+                            season_end = 20,
+                            only_current_season = FALSE)
+  unique_seasons <- unique(seasons$season)
+
+  all_levels <- seasonal_burden_levels(tsd_data, family = "lnorm", only_current_season = FALSE)
+
+  level_seasons <- sapply(all_levels, function(x) x$season)
+
+  expect_equal(unique(seasons$season)[2:4], level_seasons)
+})


### PR DESCRIPTION
When making changes in #53 for `seasonal_burden_levels()`, `current_season` was always the maximal season in the data, this so when using `only_current_season = FALSE` the prediction for each season group would have the maximal season in the output. This PR corrects this issue by selecting the maximal season in each season group to get the correct season in the output.

This PR fixes the adjustments made in 
* #53 

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR