### PR TITLE
Refactor seasonal onset

### DIFF
--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -135,6 +135,17 @@ test_that("Test that selection of current and all seasons work as expected", {
   current_onset <- seasonal_onset(tsd_data, season_start = 21, only_current_season = TRUE)
   all_onsets <- seasonal_onset(tsd_data, season_start = 21, only_current_season = FALSE)
 
+  # It actually returns one season or all seasons
   expect_equal(current_season, unique(current_onset$season))
   expect_gt(length(unique(all_onsets$season)), 1)
+
+  # It adds k-1 rows from previous season if available, if not expect 4 less observations
+  tsd_seasons <- tsd_data |>
+    dplyr::mutate(season = epi_calendar(.data$time))
+  tsd_last_season <- tsd_seasons |>
+    dplyr::filter(season == current_season) |>
+    dplyr::select(-season)
+
+  tsd_na_rows <- seasonal_onset(tsd_last_season, season_start = 21, only_current_season = TRUE)
+  expect_length(tsd_na_rows$observation, length(current_onset$observation[-(1:4)]))
 })

--- a/vignettes/seasonal_onset.Rmd
+++ b/vignettes/seasonal_onset.Rmd
@@ -20,7 +20,7 @@ library(aedseo)
 
 ## Methodology
 
-The methodology used to detect the seasonal onset of epidemics, which can be divided into two essential criteria:
+The methodology used to detect the seasonal onset of epidemics, can be divided into two essential criteria:
 
 1. The local estimate of the exponential growth rate, $r$, is significantly greater than zero.
 2. The sum of cases (SoC) over the past $k$ units of time exceeds a disease-specific threshold.


### PR DESCRIPTION
The PR refactors the `seasonal_onset()` function, such that if argument `only_current_season = TRUE` is given, it does not run the algorithm on the entire dataframe but only on the current season + k-1 observations from previous season.

This PR builds on following PR which needs to be merged before this PR is ready
* [x] #61

This PR solves
* #47 

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR