### PR TITLE
Handle input to fit_percentiles()

### DIFF
--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -89,7 +89,7 @@ fit_percentiles <- function(
 
   # If there is only one unique observation we cannot optimise -> return NA
   if (length(unique(weighted_observations$observation)) == 1) {
-    warning("Cannot optimise, all `n_peak` observations are identical. Returning NA values.", call. = FALSE)
+    warning("Cannot optimise, there is only one unique observation. Returning NA values.", call. = FALSE)
     return(list(
       conf_levels = conf_levels,
       values      = rep(NA, length(conf_levels)),

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -87,6 +87,19 @@ fit_percentiles <- function(
   family <- rlang::arg_match(family)
   optim_method <- rlang::arg_match(optim_method)
 
+  # If there is only one unique observation we cannot optimise -> return NA
+  if (length(unique(weighted_observations$observation)) == 1) {
+    warning("Cannot optimise, all `n_peak` observations are identical. Returning NA values")
+    return(list(
+      conf_levels = conf_levels,
+      values      = rep(NA, length(conf_levels)),
+      par         = c(NA, NA),
+      obj_value   = NA,
+      converged   = FALSE,
+      family      = family
+    ))
+  }
+
   # Initialising parameters based on family
   init_par_fun <- function(family, observations) {
     init_params <- switch(family,

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -89,7 +89,7 @@ fit_percentiles <- function(
 
   # If there is only one unique observation we cannot optimise -> return NA
   if (length(unique(weighted_observations$observation)) == 1) {
-    warning("Cannot optimise, all `n_peak` observations are identical. Returning NA values")
+    warning("Cannot optimise, all `n_peak` observations are identical. Returning NA values.", call. = FALSE)
     return(list(
       conf_levels = conf_levels,
       values      = rep(NA, length(conf_levels)),

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -152,7 +152,11 @@ seasonal_burden_levels <- function(
         )
       },
       intensity_levels = {
-        level_step_log <- pracma::logseq(disease_threshold, percentiles_fit$values, n = 4)
+        if (all(is.na(percentiles_fit$values))) {
+          level_step_log <- c(disease_threshold, rep(NA, 3))
+        } else {
+          level_step_log <- pracma::logseq(disease_threshold, percentiles_fit$values, n = 4)
+        }
         model_output <- list(
           season = current_season,
           values = stats::setNames(level_step_log, c("very low", "low", "medium", "high")),

--- a/tests/testthat/test-fit_percentiles.R
+++ b/tests/testthat/test-fit_percentiles.R
@@ -62,3 +62,25 @@ test_that("Test that changing weights work", {
 
   expect_gt(big_diff$values[[3]], small_diff$values[[3]])
 })
+
+test_that("Test that when there is only one unique observation return NA and warning", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Generate observations
+  unique_data <- tibble::tibble(
+    observation = c(100, 100),
+    weight = c(1, 1)
+  )
+
+  expect_warning(
+    one_unique_res <- fit_percentiles(
+      weighted_observations = unique_data
+    ),
+    "Cannot optimise, there is only one unique observation. Returning NA values."
+  )
+
+  expect_equal(
+    one_unique_res$values,
+    rep(NA, 3)
+  )
+})

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -185,3 +185,25 @@ test_that("Test that seasons are correctly increasing when only_current_season =
 
   expect_equal(unique_seasons[2:4], level_seasons)
 })
+
+test_that("Test that when no obs above disease_threshold return NA and warning", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Generate seasonal data
+  tsd_data <- generate_seasonal_data(
+    years = 3,
+  )
+
+  expect_warning(
+    obs_under_dt <- seasonal_burden_levels(
+      tsd_data,
+      disease_threshold = max(tsd_data$observation) + 50
+    ),
+    "There are no observations above `disease_threshold`. Returning NA values."
+  )
+
+  expect_equal(
+    unname(obs_under_dt$values),
+    c(max(tsd_data$observation) + 50, rep(NA, 3))
+  )
+})


### PR DESCRIPTION
## Description

Currently: 
1. If there is only one unique observation in the data frame input to `fit_quantiles()` it breaks, as we cannot optimise with only one value. 
2. If no observations are above `disease_threshold` the code breaks as there is no input for `fit_quantiles()`.

Fix: Both issues have been fixed by returning `NA` values. The user will also get a warning, but the code will not break anymore.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test

Please add tests if adding a new feature or breaking change.

- [x] Test has been added
- [ ] Test is not necessary

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
