### PR TITLE
Small bug fix to burden_levels

### DIFF
--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -123,9 +123,9 @@ seasonal_burden_levels <- function(
     dplyr::slice_max(.data$observation, n = n_peak, with_ties = FALSE, by = "season")
 
   # main level function
-  main_level_fun <- function(seasonal_tsd, current_season) {
-    # If there is no observations > disease_threshold -> return NA
-    if (nrow(seasonal_tsd) == 0) {
+  main_level_fun <- function(seasonal_data, current_season) {
+    # If there is no previous observations > disease_threshold -> return NA
+    if (nrow(seasonal_data) == 0 || all(unique(seasonal_data$season) == current_season)) {
       warning("There are no observations above `disease_threshold`. Returning NA values.", call. = FALSE)
       percentiles_fit <- list(
         conf_levels = conf_levels,
@@ -137,7 +137,7 @@ seasonal_burden_levels <- function(
       )
     } else {
       # Add weights and remove current season to get predictions for this season
-      weighted_seasonal_tsd <- seasonal_tsd |>
+      weighted_seasonal_tsd <- seasonal_data |>
         dplyr::filter(.data$season != current_season) |>
         dplyr::mutate(year = purrr::map_chr(.data$season, ~ stringr::str_extract(.x, "[0-9]+")) |>
                         as.numeric()) |>

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -218,10 +218,10 @@ test_that("Test that when only current season has an obs above disease_threshold
   )
 
   max_obs <- tsd_data |>
-    mutate(season = epi_calendar(time)) |>
-    filter(season == first(season)) |>
-    slice_max(observation, n = 1) |>
-    pull(observation)
+    dplyr::mutate(season = epi_calendar(time)) |>
+    dplyr::filter(season == first(season)) |>
+    dplyr::slice_max(observation, n = 1) |>
+    dplyr::pull(observation)
 
   expect_warning(
     obs_under_dt <- seasonal_burden_levels(

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -219,7 +219,7 @@ test_that("Test that when only current season has an obs above disease_threshold
 
   max_obs <- tsd_data |>
     dplyr::mutate(season = epi_calendar(time)) |>
-    dplyr::filter(season == first(season)) |>
+    dplyr::filter(season == dplyr::first(season)) |>
     dplyr::slice_max(observation, n = 1) |>
     dplyr::pull(observation)
 


### PR DESCRIPTION
## Description

If only the current season has an observation above the `disease_threshold` the code breaks.
We are now catching these occurances and returning NA.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test

Please add tests if adding a new feature or breaking change.

- [x] Test has been added
- [x] Test is not necessary

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
