### PR TITLE
Adding relative epidemic concentration to generate_seasonal_data()

### DIFF
--- a/R/generate_seasonal_data.R
+++ b/R/generate_seasonal_data.R
@@ -78,7 +78,7 @@ generate_seasonal_data <- function(
   checkmate::assert_false(ifelse(is.null(noise_overdispersion),
                                  FALSE,
                                  noise_overdispersion > 0 & noise_overdispersion < 1), add = coll)
-  checkmate::assert_numeric(relative_epidemic_concentration, len = 1)
+  checkmate::assert_numeric(relative_epidemic_concentration, len = 1, lower = 0)
   checkmate::assert_numeric(lower_bound, len = 1, lower = 0, add = coll)
   checkmate::reportAssertions(coll)
 

--- a/man/generate_seasonal_data.Rd
+++ b/man/generate_seasonal_data.Rd
@@ -12,6 +12,7 @@ generate_seasonal_data(
   phase = 0,
   trend_rate = NULL,
   noise_overdispersion = NULL,
+  relative_epidemic_concentration = 1,
   time_interval = c("week", "day", "month"),
   lower_bound = 1e-06
 )
@@ -33,6 +34,9 @@ of the sine wave, hence the phase shift of the seasonal wave. The phase must be 
 
 \item{noise_overdispersion}{A numeric value specifying the overdispersion of the generated data.
 0 means deterministic, 1 is pure poisson and for values > 1 a negative binomial is assumed.}
+
+\item{relative_epidemic_concentration}{A numeric that transforms the reference sinusoidal season.
+A value of 1 gives the pure sinusoidal curve, and greater values concentrate the epidemic around the peak.}
 
 \item{time_interval}{A character vector specifying the time interval. Choose between 'day', 'week', or 'month'.}
 

--- a/tests/testthat/test-generate_seasonal_data.R
+++ b/tests/testthat/test-generate_seasonal_data.R
@@ -183,3 +183,38 @@ test_that("generate_seasonal_data() - test increasing overdispersion", {
 
   expect_true(var(noise_poisson$observation) < var(noise_nbinom$observation))
 })
+
+test_that("generate_seasonal_data() - test increasing relative epidemic concentration", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Pure sinusoidal
+  sinusoidal <- generate_seasonal_data(
+    years         = 1,
+    start_date    = as.Date("2021-05-26"),
+    amplitude     = 100,
+    mean          = 100,
+    phase         = 0,
+    trend_rate    = NULL,
+    noise_overdispersion = 1,
+    relative_epidemic_concentration = 1,
+    time_interval = "week"
+  )
+
+  # Concentrated
+  concentrated <- generate_seasonal_data(
+    years         = 1,
+    start_date    = as.Date("2021-05-26"),
+    amplitude     = 100,
+    mean          = 100,
+    phase         = 0,
+    trend_rate    = NULL,
+    noise_overdispersion = 1,
+    relative_epidemic_concentration = 3,
+    time_interval = "week"
+  )
+
+  sinusoidal_0 <- nrow(sinusoidal[sinusoidal$observation == 0, ])
+  concentrated_0 <- nrow(concentrated[concentrated$observation == 0, ])
+
+  expect_gt(concentrated_0, sinusoidal_0)
+})

--- a/vignettes/generate_seasonal_wave.Rmd
+++ b/vignettes/generate_seasonal_wave.Rmd
@@ -27,7 +27,10 @@ This makes it suitable for modeling more realistic phenomena like infection rate
 The wave is defined by the following equation:
 $$
 \text{E[SeasonalWave}(t)\text{]} =
-\left( \text{mean} + \text{amplitude} \cdot \sin\left(\frac{2\pi t}{\text{period}} + \text{phase}\right) \right)
+\text{mean} + \text{amplitude} \cdot \left(
+\frac{\left(\sin\left(\frac{2\pi t}{\text{period}} + \text{phase}\right) + 1\right)^{\text{relative_epidemic_concentration}}}
+{2^{\text{relative_epidemic_concentration} - 1}} - 1
+\right)
 \cdot e^{\log(\text{trend_rate}) \cdot t}
 $$
 
@@ -39,8 +42,10 @@ Where:
 - $\text{period}$: Defines the cycle length (e.g., 52 weeks for yearly seasonality) (is calculated based on `time_interval`).
 - $\text{phase}$: Adjusts the horizontal position of the wave on the x-axis.
 - $\text{trend_rate}$: Controls the exponential growth or decay of the trend over time.
+- $\text{relative_epidemic_concentration}$: Transforms the reference sinusoidal season. A value of 1 gives the pure sinusoidal curve, and greater values concentrate the epidemic around the peak.
 
 Furthermore, noise can be controlled by the `noise_overdispersion` parameter.
+
   - 0: Deterministic, no noise.
   - 1: Poisson-distributed noise.
   - \>1: Negative binomial-distributed noise (higher values mean greater overdispersion).
@@ -184,6 +189,43 @@ sim_nb_noise <- generate_seasonal_data(
 )
 plot(
   sim_nb_noise,
+  time_interval = "5 weeks"
+)
+```
+
+### Examples of different epidemic concentrations
+
+#### Pure sinusoidal season
+```{r, dpi=300}
+sim_sinus <- generate_seasonal_data(
+  years = 2,
+  start_date = as.Date("2021-05-26"),
+  amplitude = 100,
+  mean = 100,
+  relative_epidemic_concentration = 1,
+  time_interval = "week"
+)
+plot(
+  sim_sinus,
+  time_interval = "5 weeks"
+)
+```
+
+#### Epidemic concentrated season
+The following examples illustrate how varying `elative_epidemic_concentration` affects the time period for when we have observations,
+when we increase the value the observations are concentrated around the peak. This enables the model to improve it's abbility to model
+realistic epidemic scenarios where we commonly see several weeks with no or low infection rates and a shorter epidemic period.
+```{r, dpi=300}
+sim_conc <- generate_seasonal_data(
+  years = 2,
+  start_date = as.Date("2021-05-26"),
+  amplitude = 100,
+  mean = 100,
+  relative_epidemic_concentration = 4,
+  time_interval = "week"
+)
+plot(
+  sim_conc,
   time_interval = "5 weeks"
 )
 ```

--- a/vignettes/generate_seasonal_wave.Rmd
+++ b/vignettes/generate_seasonal_wave.Rmd
@@ -212,9 +212,9 @@ plot(
 ```
 
 #### Epidemic concentrated season
-The following examples illustrate how varying `elative_epidemic_concentration` affects the time period for when we have observations,
-when we increase the value the observations are concentrated around the peak. This enables the model to improve it's abbility to model
-realistic epidemic scenarios where we commonly see several weeks with no or low infection rates and a shorter epidemic period.
+The following examples illustrate how varying `relative_epidemic_concentration` affects the time period for when we observe observations.
+When the value is increased, the observations are concentrated around the peak. This enables the model to improve it's abbility to model
+realistic epidemic scenarios, as we commonly see several weeks with no or low infection rates and a shorter epidemic period.
 ```{r, dpi=300}
 sim_conc <- generate_seasonal_data(
   years = 2,


### PR DESCRIPTION
## Description

An improvement to `generate_seasonal_data()` that now allows the user to transform the reference sinusodial season to concentrate the epidemic around the peak. This creates more realistic scenarios, where infection rates are close to 0 for a longer period.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Test

Please add tests if adding a new feature or breaking change.

- [x] Test has been added
- [ ] Test is not necessary

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
