### PR TITLE
Always include levels in output

### DIFF
--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -189,11 +189,11 @@ seasonal_burden_levels <- function(
   # Select seasons for output based on only_current_season input argument
   if (only_current_season == FALSE) {
     # Group seasons to get results for all seasons available
-    unique_seasons <- unique(rev(peak_seasonal_tsd$season))
+    unique_seasons <- unique(rev(seasonal_tsd$season))
     season_groups <- purrr::accumulate(unique_seasons, `c`)
     season_groups_data <- purrr::map(season_groups[-1], ~ peak_seasonal_tsd |> dplyr::filter(.data$season %in% .x))
-
-    level_results <- purrr::map(season_groups_data, ~ main_level_fun(.x, current_season = max(.x$season)))
+    level_results <- purrr::map2(season_groups_data, season_groups[-1],
+                                 ~ main_level_fun(.x, current_season = max(.y)))
 
   } else {
     level_results <- main_level_fun(peak_seasonal_tsd, current_season = max(seasonal_tsd$season))

--- a/man/aedseo-package.Rd
+++ b/man/aedseo-package.Rd
@@ -7,7 +7,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A powerful tool for automating the early detection of seasonal epidemic onsets in time series data. It offers the ability to estimate growth rates across consecutive time intervals, calculate the sum of cases (SoC) within those intervals, and estimate seasonal onsets within user defined seasons. With use of a disease-specific threshold it also offers the possibility to estimate seasonal onset of epidemics. Additionally it offers the ability to estimate burden levels for seasons based on historical data. It is aimed towards epidemiologists, public health professionals, and researchers seeking to identify and respond to seasonal epidemics in a timely fashion. For reference on growth rate estimation, see Walling and Lipstich (2007) \doi{10.1098/rspb.2006.3754} and Obadia et al. (2012) \doi{10.1186/1472-6947-12-147}. Seasonal burden level calculations have been inspired by The Moving Epidemic Method (MEM), see Vega and Lozano (2012) \doi{10.1111/j.1750-2659.2012.00422.x}.
+A powerful tool for automating the early detection of seasonal epidemic onsets in time series data. It offers the ability to estimate growth rates across consecutive time intervals, calculate the sum of cases (SoC) within those intervals, and estimate seasonal onsets within user defined seasons. With use of a disease-specific threshold it also offers the possibility to estimate seasonal onset of epidemics. Additionally it offers the ability to estimate burden levels for seasons based on historical data. It is aimed towards epidemiologists, public health professionals, and researchers seeking to identify and respond to seasonal epidemics in a timely fashion.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -236,3 +236,21 @@ test_that("Test that when only current season has an obs above disease_threshold
     c(max_obs + 50, rep(NA, 3))
   )
 })
+
+test_that("Test that only_current_season = FALSE/TRUE estimate same results", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Generate seasonal data
+  tsd_data <- generate_seasonal_data(years = 4, start_date = as.Date("2021-01-04"))
+
+  current_level <- seasonal_burden_levels(
+    tsd_data, family = "lnorm",
+    only_current_season = TRUE
+  )
+  all_levels <- seasonal_burden_levels(
+    tsd_data, family = "lnorm",
+    only_current_season = FALSE
+  )
+
+  expect_equal(current_level$values, all_levels[[4]]$values)
+})


### PR DESCRIPTION
## Description

If a season did not have any observations surpassing `disease_threshold` then burden levels would not be included if using `only_current_season = FALSE`.
This has been fixed, such as the levels are always included from the last season that was available.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Test

Please add tests if adding a new feature or breaking change.

- [ ] Test has been added
- [ ] Test is not necessary

### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
