### PR TITLE
Add incidence option

### DIFF
--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -98,6 +98,8 @@ combined_seasonal_output <- function(
       burden_args)
   )
 
+  if ()
+
   onset_output <- do.call(
     seasonal_onset,
     c(list(tsd = tsd, disease_threshold = disease_threshold, family = family,

--- a/tests/testthat/test-seasonal_burden_levels.R
+++ b/tests/testthat/test-seasonal_burden_levels.R
@@ -236,3 +236,53 @@ test_that("Test that when only current season has an obs above disease_threshold
     c(max_obs + 50, rep(NA, 3))
   )
 })
+
+test_that("Test that only_current_season = FALSE/TRUE estimate same results", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Generate seasonal data
+  tsd_data <- generate_seasonal_data(years = 4, start_date = as.Date("2021-01-04"))
+
+  current_level <- seasonal_burden_levels(
+    tsd_data, family = "lnorm",
+    only_current_season = TRUE
+  )
+  all_levels <- seasonal_burden_levels(
+    tsd_data, family = "lnorm",
+    only_current_season = FALSE
+  )
+
+  expect_equal(current_level$values, all_levels[[4]]$values)
+})
+
+test_that("Convert to incidence work as expected", {
+  skip_if_not_installed("withr")
+  withr::local_seed(123)
+  # Generate seasonal data
+  tsd_data <- generate_seasonal_data(years = 1, start_date = as.Date("2021-01-04"))
+  tsd_data_inc_stable <- tsd_data |>
+    dplyr::mutate(pop = 1000000)
+  tsd_data_inc <- tsd_data |>
+    dplyr::bind_cols(
+      pop = c(rep(1000000, length(tsd_data$observation) / 2),
+              rep(1000500, length(tsd_data$observation) / 2)
+      )
+    )
+
+
+  stable_inc <- seasonal_burden_levels(
+    tsd = tsd_data_inc_stable,
+    incidence_conversion = TRUE,
+    incidence_rate = 100000
+  )
+
+  seasonal_burden_levels(
+    tsd_data)
+
+  seasonal_burden_levels(
+    tsd_data_inc)
+
+
+
+})
+


### PR DESCRIPTION
## Description
Add a feature to create burden levels with observations as incidence.

Fixes: There is a bug with previous PR #83 as `combined_seasonal_output()` does not work now if `population` argument is given, which will be fixed in this PR.

## Type of Change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test

Please add tests if adding a new feature or breaking change.

- [ ] Test has been added
- [ ] Test is not necessary

### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
