### PR TITLE
Adding a workflow that uses Fedora and ATLAS BLAS/LAPACK implementaiton

### DIFF
--- a/.github/workflows/CRAN-ATLAS-fedora.yaml
+++ b/.github/workflows/CRAN-ATLAS-fedora.yaml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Test
         run: |
-          devtools::test()
+          devtools::test(stop_on_failure = TRUE)
         shell: Rscript {0}


### PR DESCRIPTION
## Description
This PR adds a Github CI action that runs `devtools::test()` on a Fedora system using the ATLAS BLAS/LAPACK implementation.

This reproduces an error seen in the CRAN test suite.

## Type of Change
CI

## Test
N/A

### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
