### PR TITLE
Add separate burden_family and family arguments and fix bugs in description

### DIFF
--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -18,10 +18,12 @@ rd_disease_threshold <- function(usage = NULL) {
         })
 }
 rd_family <- function(usage = NULL) {
-  paste("A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.",
+  paste("A character string, family-generator, or family object specifying the distribution family for growth-rate
+        modeling. Choose between 'quasipoisson' and 'poisson'.",
         if (identical(usage, "combined")) " This is passed to 'seasonal_onset()'." else "")
 }
-rd_burden_level_family <- "A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'."
+rd_burden_level_family <- "A character string specifying the family for modeling burden levels. 
+        Choose between 'lnorm', 'weibull', and 'exp'."
 rd_only_current_season <- "Should the output only include results for the current season?"
 rd_population <- "An integer vector containing the time series background population."
 rd_season_start_end <- function(usage = NULL) {

--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -18,10 +18,10 @@ rd_disease_threshold <- function(usage = NULL) {
         })
 }
 rd_family <- function(usage = NULL) {
-  paste("A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-        Must be one of: character, family-generator, or family object.",
-        ifelse(usage == "combined", paste(" This is passed to 'seasonal_onset()'.")))
+  paste("A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.",
+        if (identical(usage, "combined")) " This is passed to 'seasonal_onset()'." else "")
 }
+rd_burden_level_family <- "A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'."
 rd_only_current_season <- "Should the output only include results for the current season?"
 rd_population <- "An integer vector containing the time series background population."
 rd_season_start_end <- function(usage = NULL) {

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -12,7 +12,7 @@
 #' @inheritParams seasonal_onset
 #' @param disease_threshold `r rd_disease_threshold(usage = "combined")`
 #' @param family `r rd_family(usage = "combined")`
-#' @param family_quant A character string specifying the family for modeling burden levels.
+#' @param family_quant `r rd_burden_level_family`
 #' @param burden_level_decrease A character string specifying the burden breakpoint the observations should decrease
 #' under to reach `seasonal_offset` or before a new increase in observations can call a new wave onset if
 #' `multiple_waves` are TRUE. Choose between; "very low", "low", "medium", or "high".

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -101,9 +101,13 @@ estimate_disease_threshold <- function(
   # Estimate growth rates
   onset_output <- do.call(
     seasonal_onset,
-    c(list(tsd = tsd, season_start = season_start, season_end = season_end,
-           only_current_season = FALSE, disease_threshold = NA_real_, family = family),
-      onset_args)
+    c(
+      list(
+        tsd = tsd, season_start = season_start, season_end = season_end,
+        only_current_season = FALSE, disease_threshold = NA_real_, family = family
+      ),
+      onset_args
+    )
   )   # nolint: object_usage_linter.
 
   # Check if skip season
@@ -304,7 +308,8 @@ estimate_disease_threshold <- function(
       list(
         weighted_observations = weighted_significant_sequences |>
           dplyr::select("observation", "weight"),
-        conf_levels = conf_levels, family = burden_family),
+        conf_levels = conf_levels, family = burden_family
+      ),
       percentile_args
     )
   )

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -300,11 +300,13 @@ estimate_disease_threshold <- function(
   # Run percentiles_fit function
   percentiles_fit <- do.call(
     fit_percentiles,
-    c(list(
-           weighted_observations = weighted_significant_sequences |>
-             dplyr::select("observation", "weight"),
-           conf_levels = conf_levels, family = burden_family),
-    percentile_args)
+    c(
+      list(
+        weighted_observations = weighted_significant_sequences |>
+          dplyr::select("observation", "weight"),
+        conf_levels = conf_levels, family = burden_family),
+      percentile_args
+    )
   )
 
   fit_results <- list(

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -24,6 +24,8 @@
 #' @param conf_levels A numeric vector specifying the confidence levels for parameter estimates. The values have
 #' to be unique and in ascending order, the first percentile is the disease specific threshold.
 #' Specify one or three confidence levels e.g.: `c(0.25)` `c(0.25, 0.5, 0.75)`.
+#' @param family `r rd_family()` Passed to `seasonal_onset()` and then to `fit_growth_rate()`.
+#' @param burden_family `r rd_burden_level_family` Passed to `fit_percentiles()` as its `family` argument.
 #' @param ... Arguments passed to the `seasonal_onset()` or `fit_percentiles()` function.
 #' `only_current_season = FALSE` and `disease_threshold = NA_real_` cannot be changed in `seasonal_onset()`.
 #'
@@ -54,6 +56,15 @@ estimate_disease_threshold <- function(
   pick_significant_sequence = c("longest", "earliest"),
   season_importance_decay = 0.8,
   conf_levels = c(0.25, 0.5, 0.75),
+  family = c(
+    "quasipoisson",
+    "poisson"
+  ),
+  burden_family = c(
+    "lnorm",
+    "weibull",
+    "exp"
+  ),
   ...
 ) {
   # Check input arguments
@@ -74,21 +85,24 @@ estimate_disease_threshold <- function(
   extra_args <- list(...)
 
   # Get the allowed arguments for seasonal_burden_levels() and/or fit_percentiles()
-  percentile_allowed <- names(formals(fit_percentiles))
+  percentile_allowed <- setdiff(names(formals(fit_percentiles)), "family")
   percentile_args <- extra_args[names(extra_args) %in% percentile_allowed]
 
   # Get the allowed arguments for seasonal_onset()
-  onset_allowed <- names(formals(seasonal_onset))
+  onset_allowed <- setdiff(names(formals(seasonal_onset)), "family")
   onset_args <- extra_args[names(extra_args) %in% onset_allowed]
 
   # Throw an error if any of the inputs are not supported
   pick_significant_sequence <- match.arg(pick_significant_sequence)
+  if (is.character(burden_family)) {
+    burden_family <- rlang::arg_match(burden_family)
+  }
 
   # Estimate growth rates
   onset_output <- do.call(
     seasonal_onset,
     c(list(tsd = tsd, season_start = season_start, season_end = season_end,
-           only_current_season = FALSE, disease_threshold = NA_real_),
+           only_current_season = FALSE, disease_threshold = NA_real_, family = family),
       onset_args)
   )   # nolint: object_usage_linter.
 
@@ -289,7 +303,7 @@ estimate_disease_threshold <- function(
     c(list(
            weighted_observations = weighted_significant_sequences |>
              dplyr::select("observation", "weight"),
-           conf_levels = conf_levels),
+           conf_levels = conf_levels, family = burden_family),
     percentile_args)
   )
 

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -10,7 +10,7 @@
 #' observation has more influence on the model outcome, while lower weights reduce its impact.
 #' @param conf_levels A numeric vector specifying the confidence levels for parameter estimates. The values have
 #' to be unique and in ascending order, that is the lowest level is first and highest level is last.
-#' @param family `r rd_family()`
+#' @param family `r rd_burden_level_family`
 #' @param optim_method A character string specifying the method to be used in the optimisation. Lookup `?optim::stats`
 #' for details about methods.
 #' If using the exp family it is recommended to use Brent as it is a one-dimensional optimisation.

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -9,7 +9,7 @@
 #' Observations will be incidence if `population` and `incidence` are available in the `tsd` object.
 #'
 #' @param tsd `r rd_tsd`
-#' @param family `r rd_family()`
+#' @param family `r rd_burden_level_family`
 #' @param season_start,season_end `r rd_season_start_end()`
 #' @param method A character string specifying the model to be used in the level calculations.
 #' Both model predict the levels of the current series of observations.

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -27,10 +27,9 @@ trigger a seasonal onset alarm. If the average observation count in a window of 
 \code{disease_threshold}, a seasonal onset alarm can be triggered. For burden levels it defines the per time-step
 disease threshold that has to be surpassed for the observation to be included in the level calculations.}
 
-\item{family}{A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-Must be one of: character, family-generator, or family object.  This is passed to 'seasonal_onset()'.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.  This is passed to 'seasonal_onset()'.}
 
-\item{family_quant}{A character string specifying the family for modeling burden levels.}
+\item{family_quant}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}

--- a/man/estimate_disease_threshold.Rd
+++ b/man/estimate_disease_threshold.Rd
@@ -15,6 +15,8 @@ estimate_disease_threshold(
   pick_significant_sequence = c("longest", "earliest"),
   season_importance_decay = 0.8,
   conf_levels = c(0.25, 0.5, 0.75),
+  family = c("quasipoisson", "poisson"),
+  burden_family = c("lnorm", "weibull", "exp"),
   ...
 )
 }
@@ -49,6 +51,10 @@ seasons, such that the influence of older seasons diminishes exponentially.}
 \item{conf_levels}{A numeric vector specifying the confidence levels for parameter estimates. The values have
 to be unique and in ascending order, the first percentile is the disease specific threshold.
 Specify one or three confidence levels e.g.: \code{c(0.25)} \code{c(0.25, 0.5, 0.75)}.}
+
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'. Passed to \code{seasonal_onset()} and then to \code{fit_growth_rate()}.}
+
+\item{burden_family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'. Passed to \code{fit_percentiles()} as its \code{family} argument.}
 
 \item{...}{Arguments passed to the \code{seasonal_onset()} or \code{fit_percentiles()} function.
 \code{only_current_season = FALSE} and \code{disease_threshold = NA_real_} cannot be changed in \code{seasonal_onset()}.}

--- a/man/fit_growth_rate.Rd
+++ b/man/fit_growth_rate.Rd
@@ -18,8 +18,7 @@ fit_growth_rate(
 
 \item{level}{The confidence level for parameter estimates, a numeric value between 0 and 1.}
 
-\item{family}{A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-Must be one of: character, family-generator, or family object.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.}
 }
 \value{
 A list containing:

--- a/man/fit_percentiles.Rd
+++ b/man/fit_percentiles.Rd
@@ -21,8 +21,7 @@ observation has more influence on the model outcome, while lower weights reduce 
 \item{conf_levels}{A numeric vector specifying the confidence levels for parameter estimates. The values have
 to be unique and in ascending order, that is the lowest level is first and highest level is last.}
 
-\item{family}{A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-Must be one of: character, family-generator, or family object.}
+\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
 
 \item{optim_method}{A character string specifying the method to be used in the optimisation. Lookup \code{?optim::stats}
 for details about methods.

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -21,8 +21,7 @@ seasonal_burden_levels(
 \arguments{
 \item{tsd}{A \code{tsd} object containing time series data}
 
-\item{family}{A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-Must be one of: character, family-generator, or family object.}
+\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -28,8 +28,7 @@ seasonal_onset(
 onset alarm. If the average observation count in a window of size k exceeds \code{disease_threshold}, a seasonal
 onset alarm can be triggered.}
 
-\item{family}{A character string specifying the family for modeling. Choose between 'poisson', or 'quasipoisson'.
-Must be one of: character, family-generator, or family object.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.}
 
 \item{na_fraction_allowed}{Numeric value between 0 and 1 specifying the fraction of observations in the window
 of size k that are allowed to be NA or zero, i.e. without cases, in onset calculations.}

--- a/tests/testthat/test-estimate_disease_threshold.R
+++ b/tests/testthat/test-estimate_disease_threshold.R
@@ -145,3 +145,25 @@ test_that("Test that function returns NA when tsd is too short for the window si
     "No seasons met the `seasonal_onset()` criteria."
   )
 })
+
+test_that("family arguments are routed to onset and percentile fits", {
+  skip_if_not_installed("withr")
+  withr::local_seed(111)
+  tsd_data <- generate_seasonal_data(
+    years = 6,
+    start_date = as.Date("2021-01-01"),
+    noise_overdispersion = 3,
+    phase = 2
+  )
+
+  disease_threshold <- estimate_disease_threshold(
+    tsd_data,
+    family = "poisson",
+    burden_family = "weibull",
+    use_prev_seasons_num = 5,
+    skip_current_season = FALSE
+  )
+
+  expect_equal(attr(disease_threshold$onset_output, "family"), "poisson")
+  expect_equal(disease_threshold$optim$family, "weibull")
+})


### PR DESCRIPTION
### Motivation

- Distinguish the distribution family used for growth-rate modeling from the family used to fit burden-level percentiles so users can specify different distributions for onset vs burden estimation.
- Improve documentation to reflect that family can be a character, family-generator, or family object.
- Remove inconsistencies in the family argument description in help files.

### Description

- Added a new burden_family argument to estimate_disease_threshold() and threaded family to the seasonal_onset() call and burden_family to fit_percentiles().
- Prevented accidental forwarding of a family argument via ... by removing family from the sets of allowed forwarded arguments with setdiff() for both onset and percentile calls.
- Added rd_burden_level_family and updated rd_family doc helper and roxygen documentation across fit_percentiles, seasonal_burden_levels, combined_seasonal_output, estimate_disease_threshold, and seasonal_onset to reflect the new parameter semantics.
- Added an argument validation step for burden_family using rlang::arg_match() and updated man pages accordingly. Added a unit test test-estimate_disease_threshold.R to verify family is routed to onset and burden_family to the percentile fit.

### Testing

- Ran the package unit tests with testthat, including the new test-estimate_disease_threshold.R case, and the test suite passed.
- Verified the new routing by asserting attr(disease_threshold$onset_output, "family") equals the supplied onset family and disease_threshold$optim$family equals the supplied burden_family in the new test.
