### PR TITLE
Add binomial and quasibinomial models

### DIFF
--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -1,5 +1,5 @@
 # Model documentation
-rd_cases <- "An integer vector containing the time series cases."
+rd_cases <- "An integer vector containing the time series cases. For binomial data, use `successes` instead."
 rd_disease_threshold <- function(usage = NULL) {
   paste("A number specifying the threshold for considering a disease outbreak. Should be given as incidence if
         `population` and `incidence_denominator` are in the `tsd` object else as cases.",
@@ -19,13 +19,14 @@ rd_disease_threshold <- function(usage = NULL) {
 }
 rd_family <- function(usage = NULL) {
   paste("A character string, family-generator, or family object specifying the distribution family for growth-rate
-        modeling. Choose between 'quasipoisson' and 'poisson'.",
+        modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
+        or 'quasibinomial' for binomial data supplied as `successes` and `trials`.",
         if (identical(usage, "combined")) " This is passed to 'seasonal_onset()'." else "")
 }
-rd_burden_level_family <- "A character string specifying the family for modeling burden levels. 
-        Choose between 'lnorm', 'weibull', and 'exp'."
+rd_burden_level_family <- "A character string specifying the family for modeling burden levels.
+        Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If `NULL`, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'."
 rd_only_current_season <- "Should the output only include results for the current season?"
-rd_population <- "An integer vector containing the time series background population."
+rd_population <- "An integer vector containing the time series background population. For binomial data, use `trials` instead."
 rd_season_start_end <- function(usage = NULL) {
   paste("Integers giving the start and end weeks of the seasons to
   stratify the observations by.",
@@ -42,7 +43,7 @@ rd_seasonal_onset_return <- paste(
   "- 'lower_growth_rate': The lower bound of the growth rate's confidence interval.\n",
   "- 'upper_growth_rate': The upper bound of the growth rate's confidence interval.\n",
   "- 'growth_warning': Logical. Is the growth rate significantly higher than zero?\n",
-  "- 'average_observation_window': The average of cases or incidence within the time window.\n",
+  "- 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.\n",
   "- 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?\n",
   "- 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?\n",
   "- 'skipped_window': Logical. Was the window skipped due to missing observations?\n",
@@ -62,10 +63,12 @@ rd_seasonal_burden_levels_return <- paste(
   "         - For 'weibull': Shape parameter.\n",
   "         - For 'lnorm': Mean of the log-transformed observations.\n",
   "         - For 'exp': Rate parameter.\n",
+  "         - For 'beta': First shape parameter.\n",
   "      - 'par_2':\n",
   "         - For 'weibull': Scale parameter.\n",
   "         - For 'lnorm': Standard deviation of the log-transformed observations.\n",
   "         - For 'exp': Not applicable (set to NA).\n",
+  "         - For 'beta': Second shape parameter.\n",
   "  - 'obj_value': The value of the objective function - (negative log-likelihood), which represent the minimised\n",
   "  objective function value from the optimisation. Smaller value equals better optimisation.\n",
   "  - 'converged': Logical. TRUE if the optimisation converged.\n",
@@ -73,6 +76,7 @@ rd_seasonal_burden_levels_return <- paste(
   "     - 'weibull': Uses the Weibull distribution for fitting.\n",
   "     - 'lnorm': Uses the Log-normal distribution for fitting.\n",
   "     - 'exp': Uses the Exponential distribution for fitting.\n",
+  "     - 'beta': Uses the Beta distribution for proportional/binomial observations.\n",
   "- 'disease_threshold': The input disease threshold, which is also the very low level.\n",
   "- 'incidence_denominator': The observations per incidence-denominator.\n",
   "- Attributes: `time_interval` and `incidence_denominator`."

--- a/R/0_documentation.R
+++ b/R/0_documentation.R
@@ -23,10 +23,18 @@ rd_family <- function(usage = NULL) {
         or 'quasibinomial' for binomial data supplied as `successes` and `trials`.",
         if (identical(usage, "combined")) " This is passed to 'seasonal_onset()'." else "")
 }
-rd_burden_level_family <- "A character string specifying the family for modeling burden levels.
-        Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If `NULL`, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'."
+rd_burden_level_family <- paste(
+  "A character string specifying the family for modeling burden levels.",
+  "Choose between 'lnorm', 'weibull', 'exp', or 'beta'.",
+  "Use 'beta' for proportional/binomial data.",
+  "If `NULL`, defaults to 'beta' for proportional data and 'lnorm' otherwise.",
+  "Proportional data must use 'beta'; non-proportional data cannot use 'beta'."
+)
 rd_only_current_season <- "Should the output only include results for the current season?"
-rd_population <- "An integer vector containing the time series background population. For binomial data, use `trials` instead."
+rd_population <- paste(
+  "An integer vector containing the time series background population.",
+  "For binomial data, use `trials` instead."
+)
 rd_season_start_end <- function(usage = NULL) {
   paste("Integers giving the start and end weeks of the seasons to
   stratify the observations by.",
@@ -43,7 +51,7 @@ rd_seasonal_onset_return <- paste(
   "- 'lower_growth_rate': The lower bound of the growth rate's confidence interval.\n",
   "- 'upper_growth_rate': The upper bound of the growth rate's confidence interval.\n",
   "- 'growth_warning': Logical. Is the growth rate significantly higher than zero?\n",
-  "- 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.\n",
+  "- 'average_observation_window': The average of cases/incidence, or pooled proportion, within the time window.\n",
   "- 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?\n",
   "- 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?\n",
   "- 'skipped_window': Logical. Was the window skipped due to missing observations?\n",

--- a/R/combined_seasonal_output.R
+++ b/R/combined_seasonal_output.R
@@ -92,7 +92,8 @@ combined_seasonal_output <- function(         # nolint: cyclocomp_linter.
   family_quant = c(
     "lnorm",
     "weibull",
-    "exp"
+    "exp",
+    "beta"
   ),
   season_start = 21,
   season_end = season_start - 1,
@@ -112,6 +113,12 @@ combined_seasonal_output <- function(         # nolint: cyclocomp_linter.
   checkmate::assert_integerish(steps_with_decrease, lower = 1, add = coll)
   checkmate::reportAssertions(coll)
   burden_level_decrease <- rlang::arg_match(burden_level_decrease)
+  if (is.character(family)) {
+    family <- match.arg(family)
+  }
+  if (is.character(family_quant)) {
+    family_quant <- match.arg(family_quant)
+  }
 
   # Capture all extra arguments
   extra_args <- list(...)

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -3,7 +3,8 @@
 #' @description
 #'
 #' This function estimates the disease specific threshold, based on previous seasons.
-#' If the disease threshold is estimated between ]0:1] it will be set to 1.
+#' For count/incidence data, thresholds estimated between ]0:1] are set to 1.
+#' For binomial/proportional data, thresholds remain on the proportion scale and beta percentiles are used by default.
 #'
 #' @param tsd `r rd_tsd`
 #' @param season_start,season_end `r rd_season_start_end()`
@@ -56,17 +57,54 @@ estimate_disease_threshold <- function(
   pick_significant_sequence = c("longest", "earliest"),
   season_importance_decay = 0.8,
   conf_levels = c(0.25, 0.5, 0.75),
-  family = c(
-    "quasipoisson",
-    "poisson"
-  ),
-  burden_family = c(
-    "lnorm",
-    "weibull",
-    "exp"
-  ),
+  family = NULL,
+  burden_family = NULL,
   ...
 ) {
+  default_onset_family <- function(tsd, family) {
+    if (!is.null(family)) {
+      return(family)
+    }
+    if (all(c("successes", "trials") %in% names(tsd)) || all(c("proportion", "trials") %in% names(tsd))) {
+      "quasibinomial"
+    } else {
+      "quasipoisson"
+    }
+  }
+  family_label <- function(family) {
+    if (is.character(family)) {
+      return(family[1])
+    }
+    if (is.function(family)) {
+      return(family()$family)
+    }
+    if (inherits(family, "family")) {
+      return(family$family)
+    }
+    "custom"
+  }
+  normalize_threshold <- function(x, incidence_denominator) {
+    if (isTRUE(identical(incidence_denominator, 1))) {
+      pmin(pmax(x, 0), 1)
+    } else {
+      dplyr::if_else(dplyr::between(x, 0, 1), 1, x)
+    }
+  }
+  format_onset_output <- function(onset_output) {
+    if (isTRUE(identical(attr(onset_output, "incidence_denominator"), 1)) &&
+        all(c("successes", "trials", "proportion") %in% names(tsd))) {
+      onset_output <- onset_output |>
+        dplyr::rename(
+          successes = "cases",
+          trials = "population",
+          proportion = "incidence",
+          pooled_proportion_window = "average_observations_window",
+          proportion_threshold_warning = "average_observations_warning"
+        )
+    }
+    onset_output
+  }
+
   # Check input arguments
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_integerish(season_start, lower = 1, upper = 53,
@@ -83,6 +121,7 @@ estimate_disease_threshold <- function(
 
   # Capture all extra arguments
   extra_args <- list(...)
+  onset_family <- default_onset_family(tsd, family)
 
   # Get the allowed arguments for seasonal_burden_levels() and/or fit_percentiles()
   percentile_allowed <- setdiff(names(formals(fit_percentiles)), "family")
@@ -94,17 +133,13 @@ estimate_disease_threshold <- function(
 
   # Throw an error if any of the inputs are not supported
   pick_significant_sequence <- match.arg(pick_significant_sequence)
-  if (is.character(burden_family)) {
-    burden_family <- rlang::arg_match(burden_family)
-  }
-
   # Estimate growth rates
   onset_output <- do.call(
     seasonal_onset,
     c(
       list(
         tsd = tsd, season_start = season_start, season_end = season_end,
-        only_current_season = FALSE, disease_threshold = NA_real_, family = family
+        only_current_season = FALSE, disease_threshold = NA_real_, family = onset_family
       ),
       onset_args
     )
@@ -129,10 +164,11 @@ estimate_disease_threshold <- function(
                       use_prev_seasons_num = use_prev_seasons_num,
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
-                      percentiles = conf_levels),
+                      family = family_label(onset_family),
+                    percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
-      onset_output = onset_output
+      onset_output = format_onset_output(onset_output)
     )
     class(no_results) <- "tsd_disease_threshold"
     return(no_results)
@@ -229,10 +265,11 @@ estimate_disease_threshold <- function(
                       use_prev_seasons_num = use_prev_seasons_num,
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
-                      percentiles = conf_levels),
+                      family = family_label(onset_family),
+                    percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
-      onset_output = onset_output
+      onset_output = format_onset_output(onset_output)
     )
     class(no_results) <- "tsd_disease_threshold"
     return(no_results)
@@ -276,17 +313,18 @@ estimate_disease_threshold <- function(
     same_result <- list(
       note = "Only one season is used to determine the threshold.",
       seasons = unique(per_season_sequence$season),
-      disease_threshold = dplyr::if_else(dplyr::between(disease_threshold, 0, 1), 1, disease_threshold),
+      disease_threshold = normalize_threshold(disease_threshold, attr(onset_output, "incidence_denominator")),
       optim = NA,
       settings = list(skip_current_season = skip_current_season,
                       min_significant_time = min_significant_time,
                       use_prev_seasons_num = use_prev_seasons_num,
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
-                      percentiles = conf_levels),
+                      family = family_label(onset_family),
+                    percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
-      onset_output = onset_output
+      onset_output = format_onset_output(onset_output)
     )
 
     class(same_result) <- "tsd_disease_threshold"
@@ -300,6 +338,35 @@ estimate_disease_threshold <- function(
     dplyr::mutate(weight = season_importance_decay^(max(.data$year) - .data$year)) |>
     dplyr::select(-"year") |>
     dplyr::rename(observation = "start_average_observations_window")
+
+  # For proportion-based data, account for binomial precision by upweighting
+  # observations from larger trial counts.
+  if (isTRUE(identical(attr(onset_output, "incidence_denominator"), 1)) && "population" %in% names(onset_output)) {
+    k_window <- attr(onset_output, "k")
+    if (is.null(k_window) || !is.numeric(k_window) || length(k_window) != 1) {
+      k_window <- 5
+    }
+    onset_with_window <- onset_output |>
+      dplyr::arrange(.data$reference_time) |>
+      dplyr::mutate(
+        idx = dplyr::row_number(),
+        population_window = purrr::map_dbl(
+          .data$idx,
+          ~ sum(.data$population[max(1, .x - k_window + 1):.x], na.rm = TRUE)
+        )
+      )
+    pop_weights <- onset_with_window |>
+      dplyr::filter(.data$reference_time %in% weighted_significant_sequences$start_window_time) |>
+      dplyr::select("season", "reference_time", "population_window") |>
+      dplyr::rename(start_window_time = "reference_time", population_weight = "population_window")
+    weighted_significant_sequences <- weighted_significant_sequences |>
+      dplyr::left_join(pop_weights, by = c("season", "start_window_time")) |>
+      dplyr::mutate(
+        population_weight = dplyr::coalesce(.data$population_weight, 1),
+        weight = .data$weight * .data$population_weight
+      ) |>
+      dplyr::select(-"population_weight")
+  }
 
   # Run percentiles_fit function
   percentiles_fit <- do.call(
@@ -317,17 +384,18 @@ estimate_disease_threshold <- function(
   fit_results <- list(
     note = "Sufficient information to estimate percentiles.",
     seasons = unique(weighted_significant_sequences$season),
-    disease_threshold = dplyr::if_else(dplyr::between(percentiles_fit$values[1], 0, 1), 1, percentiles_fit$values[1]),
+    disease_threshold = normalize_threshold(percentiles_fit$values[1], attr(onset_output, "incidence_denominator")),
     optim = percentiles_fit,
     settings = list(skip_current_season = skip_current_season,
                     min_significant_time = min_significant_time,
                     use_prev_seasons_num = use_prev_seasons_num,
                     pick_significant_sequence = pick_significant_sequence,
                     season_importance_decay = season_importance_decay,
+                    family = family_label(onset_family),
                     percentiles = conf_levels),
     incidence_denominator = attr(onset_output, "incidence_denominator"),
     time_interval = attr(onset_output, "time_interval"),
-    onset_output = onset_output
+    onset_output = format_onset_output(onset_output)
   )
 
   # Add class, and keep attributes from the `tsd` class

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -47,25 +47,28 @@
 #' estimate_disease_threshold(tsd_data)
 #'
 estimate_disease_threshold <- function(
-  tsd,
-  season_start = 21,
-  season_end = season_start - 1,
-  skip_current_season = TRUE,
-  min_significant_time = 3,
-  max_gap_time = 1,
-  use_prev_seasons_num = 3,
-  pick_significant_sequence = c("longest", "earliest"),
-  season_importance_decay = 0.8,
-  conf_levels = c(0.25, 0.5, 0.75),
-  family = NULL,
-  burden_family = NULL,
-  ...
+    tsd,
+    season_start = 21,
+    season_end = season_start - 1,
+    skip_current_season = TRUE,
+    min_significant_time = 3,
+    max_gap_time = 1,
+    use_prev_seasons_num = 3,
+    pick_significant_sequence = c("longest", "earliest"),
+    season_importance_decay = 0.8,
+    conf_levels = c(0.25, 0.5, 0.75),
+    family = NULL,
+    burden_family = NULL,
+    ...
 ) {
+  is_binomial_tsd <- function(tsd) {
+    "trials" %in% names(tsd) && any(c("successes", "proportion") %in% names(tsd))
+  }
   default_onset_family <- function(tsd, family) {
     if (!is.null(family)) {
       return(family)
     }
-    if (all(c("successes", "trials") %in% names(tsd)) || all(c("proportion", "trials") %in% names(tsd))) {
+    if (is_binomial_tsd(tsd)) {
       "quasibinomial"
     } else {
       "quasipoisson"
@@ -83,16 +86,15 @@ estimate_disease_threshold <- function(
     }
     "custom"
   }
-  normalize_threshold <- function(x, incidence_denominator) {
-    if (isTRUE(identical(incidence_denominator, 1))) {
+  normalize_threshold <- function(x, is_binomial) {
+    if (is_binomial) {
       pmin(pmax(x, 0), 1)
     } else {
       dplyr::if_else(dplyr::between(x, 0, 1), 1, x)
     }
   }
   format_onset_output <- function(onset_output) {
-    if (isTRUE(identical(attr(onset_output, "incidence_denominator"), 1)) &&
-        all(c("successes", "trials", "proportion") %in% names(tsd))) {
+    if (is_binomial_input) {
       onset_output <- onset_output |>
         dplyr::rename(
           successes = "cases",
@@ -121,6 +123,7 @@ estimate_disease_threshold <- function(
 
   # Capture all extra arguments
   extra_args <- list(...)
+  is_binomial_input <- is_binomial_tsd(tsd)
   onset_family <- default_onset_family(tsd, family)
 
   # Get the allowed arguments for seasonal_burden_levels() and/or fit_percentiles()
@@ -165,7 +168,7 @@ estimate_disease_threshold <- function(
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
                       family = family_label(onset_family),
-                    percentiles = conf_levels),
+                      percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
       onset_output = format_onset_output(onset_output)
@@ -266,7 +269,7 @@ estimate_disease_threshold <- function(
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
                       family = family_label(onset_family),
-                    percentiles = conf_levels),
+                      percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
       onset_output = format_onset_output(onset_output)
@@ -305,15 +308,15 @@ estimate_disease_threshold <- function(
   # If there is only one season with observation that will be the threshold
   # If all observations are 1, the disease threshold will be 1
   if (nrow(per_season_sequence) == 1 ||
-        length(unique(per_season_sequence$start_average_observations_window)) == 1 ||
-        all(unique(per_season_sequence$start_average_observations_window) == 1)) {
+      length(unique(per_season_sequence$start_average_observations_window)) == 1 ||
+      all(unique(per_season_sequence$start_average_observations_window) == 1)) {
 
     disease_threshold <- unique(per_season_sequence$start_average_observations_window)
 
     same_result <- list(
       note = "Only one season is used to determine the threshold.",
       seasons = unique(per_season_sequence$season),
-      disease_threshold = normalize_threshold(disease_threshold, attr(onset_output, "incidence_denominator")),
+      disease_threshold = normalize_threshold(disease_threshold, is_binomial_input),
       optim = NA,
       settings = list(skip_current_season = skip_current_season,
                       min_significant_time = min_significant_time,
@@ -321,7 +324,7 @@ estimate_disease_threshold <- function(
                       pick_significant_sequence = pick_significant_sequence,
                       season_importance_decay = season_importance_decay,
                       family = family_label(onset_family),
-                    percentiles = conf_levels),
+                      percentiles = conf_levels),
       incidence_denominator = attr(onset_output, "incidence_denominator"),
       time_interval = attr(onset_output, "time_interval"),
       onset_output = format_onset_output(onset_output)
@@ -341,7 +344,7 @@ estimate_disease_threshold <- function(
 
   # For proportion-based data, account for binomial precision by upweighting
   # observations from larger trial counts.
-  if (isTRUE(identical(attr(onset_output, "incidence_denominator"), 1)) && "population" %in% names(onset_output)) {
+  if (is_binomial_input) {
     k_window <- attr(onset_output, "k")
     if (is.null(k_window) || !is.numeric(k_window) || length(k_window) != 1) {
       k_window <- 5
@@ -384,7 +387,7 @@ estimate_disease_threshold <- function(
   fit_results <- list(
     note = "Sufficient information to estimate percentiles.",
     seasons = unique(weighted_significant_sequences$season),
-    disease_threshold = normalize_threshold(percentiles_fit$values[1], attr(onset_output, "incidence_denominator")),
+    disease_threshold = normalize_threshold(percentiles_fit$values[1], is_binomial_input),
     optim = percentiles_fit,
     settings = list(skip_current_season = skip_current_season,
                     min_significant_time = min_significant_time,

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -365,7 +365,9 @@ estimate_disease_threshold <- function(
         idx = dplyr::row_number(),
         population_window = purrr::map_dbl(
           .data$idx,
-          ~ sum(onset_population[max(1, .x - k_window + 1):.x], na.rm = TRUE)
+          function(idx) {
+            sum(onset_population[max(1, idx - k_window + 1):idx], na.rm = TRUE)
+          }
         )
       )
     pop_weights <- onset_with_window |>

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -305,7 +305,8 @@ estimate_disease_threshold <- function(
     per_season_sequence <- per_season_sequence |>
       dplyr::mutate(
         start_average_observations_window = dplyr::if_else(
-          .data$start_average_observations_window <= 0, 1,
+          .data$start_average_observations_window <= 0,
+          1,
           .data$start_average_observations_window
         )
       )
@@ -355,13 +356,16 @@ estimate_disease_threshold <- function(
     if (is.null(k_window) || !is.numeric(k_window) || length(k_window) != 1) {
       k_window <- 5
     }
+    onset_population <- onset_output |>
+      dplyr::arrange(.data$reference_time) |>
+      dplyr::pull("population")
     onset_with_window <- onset_output |>
       dplyr::arrange(.data$reference_time) |>
       dplyr::mutate(
         idx = dplyr::row_number(),
         population_window = purrr::map_dbl(
           .data$idx,
-          ~ sum(.data$population[max(1, .x - k_window + 1):.x], na.rm = TRUE)
+          ~ sum(onset_population[max(1, .x - k_window + 1):.x], na.rm = TRUE)
         )
       )
     pop_weights <- onset_with_window |>

--- a/R/estimate_disease_threshold.R
+++ b/R/estimate_disease_threshold.R
@@ -47,19 +47,19 @@
 #' estimate_disease_threshold(tsd_data)
 #'
 estimate_disease_threshold <- function(
-    tsd,
-    season_start = 21,
-    season_end = season_start - 1,
-    skip_current_season = TRUE,
-    min_significant_time = 3,
-    max_gap_time = 1,
-    use_prev_seasons_num = 3,
-    pick_significant_sequence = c("longest", "earliest"),
-    season_importance_decay = 0.8,
-    conf_levels = c(0.25, 0.5, 0.75),
-    family = NULL,
-    burden_family = NULL,
-    ...
+  tsd,
+  season_start = 21,
+  season_end = season_start - 1,
+  skip_current_season = TRUE,
+  min_significant_time = 3,
+  max_gap_time = 1,
+  use_prev_seasons_num = 3,
+  pick_significant_sequence = c("longest", "earliest"),
+  season_importance_decay = 0.8,
+  conf_levels = c(0.25, 0.5, 0.75),
+  family = NULL,
+  burden_family = NULL,
+  ...
 ) {
   is_binomial_tsd <- function(tsd) {
     "trials" %in% names(tsd) && any(c("successes", "proportion") %in% names(tsd))
@@ -180,11 +180,17 @@ estimate_disease_threshold <- function(
   # Count consecutive significant observations
   sign_warnings <- consecutive_growth_warnings(onset_output)
 
-  # Peak time per season
+  # Peak time per season. Prefer incidence when it is available, because it
+  # accounts for population/trial denominators; otherwise use raw cases.
+  peak_observation <- if ("incidence" %in% names(onset_output) && !all(is.na(onset_output$incidence))) {
+    "incidence"
+  } else {
+    "cases"
+  }
   peaks <- onset_output |>
     dplyr::arrange(.data$season) |>
     dplyr::group_by(.data$season) |>
-    dplyr::slice_max(order_by = .data$cases, n = 1, with_ties = FALSE, na_rm = TRUE) |>
+    dplyr::slice_max(order_by = .data[[peak_observation]], n = 1, with_ties = FALSE, na_rm = TRUE) |>
     dplyr::ungroup() |>
     dplyr::select("season", peak_time = "reference_time") |>
     dplyr::slice_tail(n = use_prev_seasons_num)
@@ -308,8 +314,8 @@ estimate_disease_threshold <- function(
   # If there is only one season with observation that will be the threshold
   # If all observations are 1, the disease threshold will be 1
   if (nrow(per_season_sequence) == 1 ||
-      length(unique(per_season_sequence$start_average_observations_window)) == 1 ||
-      all(unique(per_season_sequence$start_average_observations_window) == 1)) {
+        length(unique(per_season_sequence$start_average_observations_window)) == 1 ||
+        all(unique(per_season_sequence$start_average_observations_window) == 1)) {
 
     disease_threshold <- unique(per_season_sequence$start_average_observations_window)
 

--- a/R/fit_growth_rate.R
+++ b/R/fit_growth_rate.R
@@ -1,12 +1,17 @@
-#' Fit a growth rate model to time series cases.
+#' Fit a growth rate model to time series observations.
 #'
 #' @description
 #'
-#' This function fits a growth rate model to time series cases and provides parameter estimates along with
-#' confidence intervals.
+#' This function fits a growth rate model to time series observations and provides parameter estimates along with
+#' confidence intervals. For binomial data, supply successes and trials and use `family = "binomial"` or
+#' `family = "quasibinomial"`.
 #'
 #' @param cases `r rd_cases`
+#' @param successes An integer vector containing binomial successes. This is an alias for `cases` for
+#' binomial/quasibinomial models.
 #' @param population `r rd_population`
+#' @param trials An integer vector containing binomial trials. This is an alias for `population` for
+#' binomial/quasibinomial models.
 #' @param level The confidence level for parameter estimates, a numeric value between 0 and 1.
 #' @param family `r rd_family()`
 #'
@@ -27,20 +32,43 @@
 #'   level = 0.95,
 #'   family = "poisson"
 #' )
+#'
+#' # Fit a binomial growth rate model to successes out of trials
+#' fit_growth_rate(
+#'   successes = c(1, 2, 3, 4),
+#'   trials = c(10, 10, 10, 10),
+#'   family = "binomial"
+#' )
 fit_growth_rate <- function(
-  cases,
+  cases = NULL,
+  successes = NULL,
   population = NULL,
+  trials = NULL,
   level = 0.95,
   family = c(
     "quasipoisson",
-    "poisson"
+    "poisson",
+    "quasibinomial",
+    "binomial"
   )
 ) {
   safe_confint <- purrr::safely(stats::confint)
 
   # Check input arguments
   coll <- checkmate::makeAssertCollection()
-  checkmate::assert_numeric(cases, add = coll)
+  if (!is.null(successes)) {
+    if (!is.null(cases)) {
+      coll$push("Supply only one of `cases` or `successes`")
+    }
+    cases <- successes
+  }
+  if (!is.null(trials)) {
+    if (!is.null(population)) {
+      coll$push("Supply only one of `population` or `trials`")
+    }
+    population <- trials
+  }
+  checkmate::assert_numeric(cases, null.ok = FALSE, add = coll)
   checkmate::assert_numeric(level, lower = 0, upper = 1, add = coll)
   checkmate::assert_numeric(population, null.ok = TRUE, add = coll)
   # Match the selected model
@@ -57,27 +85,45 @@ fit_growth_rate <- function(
   }
   checkmate::reportAssertions(coll) # Assert that we have an object before going further
   checkmate::assert_names(names(fam_obj), must.include = c("family", "link"), add = coll)
-  checkmate::assert_choice(fam_obj$family, choices = c("poisson", "quasipoisson"), add = coll)
+  checkmate::assert_choice(fam_obj$family, choices = c("poisson", "quasipoisson", "binomial", "quasibinomial"), add = coll)
+  if (fam_obj$family %in% c("binomial", "quasibinomial")) {
+    if (is.null(population)) {
+      coll$push("`trials` (or `population`) must be supplied for binomial and quasibinomial models")
+    } else {
+      checkmate::assert_true(all(cases >= 0, na.rm = TRUE), add = coll)
+      checkmate::assert_true(all(population > 0, na.rm = TRUE), add = coll)
+      checkmate::assert_true(all(cases <= population, na.rm = TRUE), add = coll)
+    }
+  }
   checkmate::reportAssertions(coll)
 
   # Construct the data with growth rates for the glm model
   growth_data <- purrr::compact(list(
     growth_rate = seq_along(cases),
-    x = cases,
-    population = population
+    cases = cases,
+    population = population,
+    successes = cases,
+    trials = population
   )) |>
     tibble::as_tibble()
 
   # Construct formula terms
   terms <- if (is.null(population)) {
     "growth_rate"
+  } else if (fam_obj$family %in% c("binomial", "quasibinomial")) {
+    "growth_rate"
   } else {
     c("growth_rate", "offset(log(population))")
+  }
+  response <- if (fam_obj$family %in% c("binomial", "quasibinomial")) {
+    "cbind(successes, trials - successes)"
+  } else {
+    "cases"
   }
 
   # Fit the model
   growth_fit <- stats::glm(
-    formula = stats::reformulate(response = "cases", termlabels = terms),
+    formula = stats::as.formula(paste(response, "~", paste(terms, collapse = " + "))),
     data = growth_data,
     family = fam_obj
   )

--- a/R/fit_growth_rate.R
+++ b/R/fit_growth_rate.R
@@ -85,7 +85,11 @@ fit_growth_rate <- function(
   }
   checkmate::reportAssertions(coll) # Assert that we have an object before going further
   checkmate::assert_names(names(fam_obj), must.include = c("family", "link"), add = coll)
-  checkmate::assert_choice(fam_obj$family, choices = c("poisson", "quasipoisson", "binomial", "quasibinomial"), add = coll)
+  checkmate::assert_choice(
+    fam_obj$family,
+    choices = c("poisson", "quasipoisson", "binomial", "quasibinomial"),
+    add = coll
+  )
   if (fam_obj$family %in% c("binomial", "quasibinomial")) {
     if (is.null(population)) {
       coll$push("`trials` (or `population`) must be supplied for binomial and quasibinomial models")

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -2,11 +2,11 @@
 #'
 #' @description
 #'
-#' This function estimates the percentiles of weighted time series cases or incidences.
+#' This function estimates the percentiles of weighted time series cases, incidences, or proportions.
 #' The output contains the percentiles from the fitted distribution.
 #'
-#' @param weighted_observations A tibble containing two columns of length n; `observation`, which contains either cases
-#' or incidences, and `weight`, which is the importance assigned to the observation. Higher weights indicate that an
+#' @param weighted_observations A tibble containing two columns of length n; `observation`, which contains cases,
+#' incidences, or proportions, and `weight`, which is the importance assigned to the observation. Higher weights indicate that an
 #' observation has more influence on the model outcome, while lower weights reduce its impact.
 #' @param conf_levels A numeric vector specifying the confidence levels for parameter estimates. The values have
 #' to be unique and in ascending order, that is the lowest level is first and highest level is last.
@@ -25,10 +25,12 @@
 #'          - For 'weibull': Shape parameter (k).
 #'          - For 'lnorm': Mean of the log-transformed observations.
 #'          - For 'exp': Rate parameter (rate).
+#'          - For 'beta': First shape parameter.
 #'       - 'par_2':
 #'          - For 'weibull': Scale parameter (scale).
 #'          - For 'lnorm': Standard deviation of the log-transformed observations.
 #'          - For 'exp': Not applicable (set to NA).
+#'          - For 'beta': Second shape parameter.
 #'   - 'obj_value': The value of the objective function - (negative log-likelihood), which represent the minimized
 #'                  objective function value from the optimisation. Smaller value equals better optimisation.
 #'   - 'converged': Logical. TRUE if the optimisation converged.
@@ -36,6 +38,7 @@
 #'      - 'weibull': Uses the Weibull distribution for fitting.
 #'      - 'lnorm': Uses the Log-normal distribution for fitting.
 #'      - 'exp': Uses the Exponential distribution for fitting.
+#'      - 'beta': Uses the Beta distribution for proportional/binomial observations.
 #'
 #' @export
 #'
@@ -61,9 +64,7 @@
 fit_percentiles <- function(
   weighted_observations,
   conf_levels = c(0.50, 0.90, 0.95),
-  family = c("lnorm",
-             "weibull",
-             "exp"),
+  family = NULL,
   optim_method = c("Nelder-Mead",
                    "BFGS",
                    "CG",
@@ -85,14 +86,14 @@ fit_percentiles <- function(
   checkmate::assert_names(
     colnames(weighted_observations),
     must.include = "weight",
-    subset.of = c("weight", "cases", "incidence", "observation"),
+    subset.of = c("weight", "cases", "incidence", "proportion", "successes", "observation"),
     add = coll
   )
   checkmate::assert_numeric(lower_optim, add = coll)
   checkmate::assert_numeric(upper_optim, add = coll)
   checkmate::reportAssertions(coll)
+  family_candidates <- c("lnorm", "weibull", "exp", "beta")
   # Match the arguments.
-  family <- rlang::arg_match(family)
   optim_method <- rlang::arg_match(optim_method)
 
   # Rename cases or incidence to observation if they are present and observation is not
@@ -105,6 +106,34 @@ fit_percentiles <- function(
   ) {
     weighted_observations <- weighted_observations |>
       dplyr::rename(observation = "cases")
+  }
+  if ("proportion" %in% names(weighted_observations) &&
+      !any(c("observation", "incidence", "cases") %in% names(weighted_observations))
+  ) {
+    weighted_observations <- weighted_observations |>
+      dplyr::rename(observation = "proportion")
+  }
+  if ("successes" %in% names(weighted_observations) &&
+      !any(c("observation", "incidence", "cases", "proportion") %in% names(weighted_observations))
+  ) {
+    weighted_observations <- weighted_observations |>
+      dplyr::rename(observation = "successes")
+  }
+
+  is_proportional_data <- all(
+    weighted_observations$observation >= 0 & weighted_observations$observation <= 1,
+    na.rm = TRUE
+  )
+  if (is.null(family)) {
+    family <- if (is_proportional_data) "beta" else "lnorm"
+  } else {
+    family <- rlang::arg_match(family, family_candidates)
+    if (is_proportional_data && family != "beta") {
+      stop("Only the 'beta' family can be used for proportional data.", call. = FALSE)
+    }
+    if (!is_proportional_data && family == "beta") {
+      stop("The 'beta' family can only be used for proportional data.", call. = FALSE)
+    }
   }
 
   # If there is only one unique observation we cannot optimise -> return NA
@@ -125,7 +154,15 @@ fit_percentiles <- function(
     init_params <- switch(family,
       weibull = log(c(1.5, mean(observations))),
       lnorm = c(mean(log(observations)), log(stats::sd(log(observations)))),
-      exp = log(1.5)
+      exp = log(1.5),
+      beta = {
+        mu <- mean(observations)
+        v <- stats::var(observations)
+        precision <- if (is.na(v) || v <= 0 || v >= mu * (1 - mu)) 10 else (mu * (1 - mu) / v) - 1
+        alpha <- max(mu * precision, 1e-3)
+        beta <- max((1 - mu) * precision, 1e-3)
+        log(c(alpha, beta))
+      }
     )
     init_params
   }
@@ -136,7 +173,12 @@ fit_percentiles <- function(
       weibull = stats::dweibull(weighted_observations$observation, shape = exp(par[1]), scale = exp(par[2]),
                                 log = TRUE),
       lnorm = stats::dlnorm(weighted_observations$observation, meanlog =  par[1], sdlog = exp(par[2]), log = TRUE),
-      exp = stats::dexp(weighted_observations$observation, rate = exp(par[1]), log = TRUE)
+      exp = stats::dexp(weighted_observations$observation, rate = exp(par[1]), log = TRUE),
+      beta = {
+        eps <- sqrt(.Machine$double.eps)
+        x <- pmin(pmax(weighted_observations$observation, eps), 1 - eps)
+        stats::dbeta(x, shape1 = exp(par[1]), shape2 = exp(par[2]), log = TRUE)
+      }
     )
     -sum(log_probability * weighted_observations$weight)
   }
@@ -157,14 +199,16 @@ fit_percentiles <- function(
   par_fit <- switch(family,
     weibull = exp(optim_obj$par),
     lnorm = c(optim_obj$par[1], exp(optim_obj$par[2])),
-    exp = c(exp(optim_obj$par), NA)
+    exp = c(exp(optim_obj$par), NA),
+    beta = exp(optim_obj$par)
   )
 
   # Estimate the low, medium, high intensity levels based on input `conf_levels`
   percentiles <- switch(family,
     weibull = stats::qweibull(p = conf_levels, shape = par_fit[1], scale = par_fit[2]),
     lnorm = stats::qlnorm(p = conf_levels, meanlog = par_fit[1], sdlog = par_fit[2]),
-    exp = stats::qexp(p = conf_levels, rate = par_fit[1])
+    exp = stats::qexp(p = conf_levels, rate = par_fit[1]),
+    beta = stats::qbeta(p = conf_levels, shape1 = par_fit[1], shape2 = par_fit[2])
   )
 
   # Create return fit parameters

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -6,8 +6,8 @@
 #' The output contains the percentiles from the fitted distribution.
 #'
 #' @param weighted_observations A tibble containing two columns of length n; `observation`, which contains cases,
-#' incidences, or proportions, and `weight`, which is the importance assigned to the observation. Higher weights indicate
-#' that an observation has more influence on the model outcome, while lower weights reduce its impact.
+#' incidences, or proportions, and `weight`, which is the importance assigned to the observation. Higher weights
+#' indicate that an observation has more influence on the model outcome, while lower weights reduce its impact.
 #' @param conf_levels A numeric vector specifying the confidence levels for parameter estimates. The values have
 #' to be unique and in ascending order, that is the lowest level is first and highest level is last.
 #' @param family `r rd_burden_level_family`
@@ -59,7 +59,7 @@
 #' fit_percentiles(
 #'   weighted_observations = data_input,
 #'   conf_levels = c(0.50, 0.90, 0.95),
-#'   family= "weibull"
+#'   family = "weibull"
 #' )
 fit_percentiles <- function(
   weighted_observations,

--- a/R/fit_percentiles.R
+++ b/R/fit_percentiles.R
@@ -6,8 +6,8 @@
 #' The output contains the percentiles from the fitted distribution.
 #'
 #' @param weighted_observations A tibble containing two columns of length n; `observation`, which contains cases,
-#' incidences, or proportions, and `weight`, which is the importance assigned to the observation. Higher weights indicate that an
-#' observation has more influence on the model outcome, while lower weights reduce its impact.
+#' incidences, or proportions, and `weight`, which is the importance assigned to the observation. Higher weights indicate
+#' that an observation has more influence on the model outcome, while lower weights reduce its impact.
 #' @param conf_levels A numeric vector specifying the confidence levels for parameter estimates. The values have
 #' to be unique and in ascending order, that is the lowest level is first and highest level is last.
 #' @param family `r rd_burden_level_family`

--- a/R/historical_summary.R
+++ b/R/historical_summary.R
@@ -53,7 +53,10 @@ historical_summary <- function(
   # Check input arguments
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_class(onset_output, "tsd_onset", add = coll)
-  if (!"seasonal_onset" %in% names(onset_output)) {
+  if (
+    !"seasonal_onset" %in% names(onset_output) ||
+      is.na(attr(onset_output, "disease_threshold"))
+  ) {
     coll$push("Column 'seasonal_onset' not found in tsd_onset object.")
   }
   if ("seasonal_onset" %in% names(onset_output) && all(onset_output$season == "not_defined")) {

--- a/R/seasonal_burden_levels.R
+++ b/R/seasonal_burden_levels.R
@@ -74,7 +74,8 @@ seasonal_burden_levels <- function(
   tsd,
   family = c("lnorm",
              "weibull",
-             "exp"),
+             "exp",
+             "beta"),
   season_start = 21,
   season_end = season_start - 1,
   method = c("intensity_levels", "peak_levels"),
@@ -87,6 +88,7 @@ seasonal_burden_levels <- function(
 ) {
   # Check input arguments
   method <- rlang::arg_match(method)
+  family <- rlang::arg_match(family)
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_data_frame(tsd, add = coll)
   checkmate::assert_class(tsd, "tsd", add = coll)

--- a/R/seasonal_onset.R
+++ b/R/seasonal_onset.R
@@ -70,6 +70,8 @@ seasonal_onset <- function(
         population = .data$trials,
         incidence = if ("proportion" %in% names(tsd)) .data$proportion else .data$successes / .data$trials
       )
+    # Keep binomial rolling windows on the proportion scale, including for
+    # manually constructed tsd objects whose denominator attribute is not 1.
     attr(tsd, "incidence_denominator") <- 1
   }
   checkmate::assert_names(

--- a/R/seasonal_onset.R
+++ b/R/seasonal_onset.R
@@ -3,9 +3,11 @@
 #' @description
 #'
 #' This function performs automated and early detection of seasonal epidemic onsets on a `tsd` object.
-#' It estimates growth rates and calculates the average sum of cases in consecutive time intervals (`k`).
-#' If the time series data includes `population` it will be used as offset to adjust the growth rate in the glm,
-#' additionally the output will include incidence, population and average sum of incidence.
+#' It estimates growth rates and calculates the average observation in consecutive time intervals (`k`).
+#' For count/incidence data, Poisson/quasi-Poisson models use `population` as an offset when available.
+#' For binomial data created with `successes`/`trials` or `proportion`/`trials`, use `family = "binomial"`
+#' or `family = "quasibinomial"`; `trials` is used as the denominator and the rolling window is reported
+#' as a pooled proportion.
 #'
 #' @param tsd `r rd_tsd`
 #' @param k An integer specifying the window size for modeling growth rates and average sum of cases.
@@ -46,7 +48,9 @@ seasonal_onset <- function(
   disease_threshold = NA_real_,
   family = c(
     "quasipoisson",
-    "poisson"
+    "poisson",
+    "quasibinomial",
+    "binomial"
     # TODO: #10 Include negative.binomial regressions. @telkamp7
   ),
   na_fraction_allowed = 0.4,
@@ -58,10 +62,20 @@ seasonal_onset <- function(
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_data_frame(tsd, add = coll)
   checkmate::assert_class(tsd, "tsd", add = coll)
+  # Support binomial/quasibinomial-oriented column names from to_time_series()
+  if (all(c("successes", "trials") %in% names(tsd))) {
+    tsd <- tsd |>
+      dplyr::mutate(
+        cases = .data$successes,
+        population = .data$trials,
+        incidence = if ("proportion" %in% names(tsd)) .data$proportion else .data$successes / .data$trials
+      )
+    attr(tsd, "incidence_denominator") <- 1
+  }
   checkmate::assert_names(
     colnames(tsd),
     must.include = c("time", "cases"),
-    subset.of = c("time", "cases", "incidence", "population"),
+    subset.of = c("time", "cases", "incidence", "population", "successes", "proportion", "trials"),
     add = coll
   )
   checkmate::assert_numeric(level, lower = 0, upper = 1, add = coll)
@@ -74,6 +88,9 @@ seasonal_onset <- function(
   checkmate::assert_integerish(season_end, lower = 1, upper = 53,
                                null.ok = TRUE, add = coll)
   checkmate::assert_logical(only_current_season, null.ok = TRUE, add = coll)
+  if (is.character(family)) {
+    family <- match.arg(family)
+  }
   if (!is.null(season_start) && is.null(season_end)) {
     coll$push("If season_start is assigned season_end must also be assigned.")
   }
@@ -156,6 +173,7 @@ seasonal_onset <- function(
       average_observations_window = NA_real_,
       average_observations_warning = FALSE,
       seasonal_onset_alarm = FALSE,
+      seasonal_onset = FALSE,
       skipped_window = TRUE,
       converged = FALSE
     )
@@ -202,14 +220,27 @@ seasonal_onset <- function(
     growth_warning <- growth_rates$estimate[2] > 0
 
     if (use_incidence) {
-      # Calculate average incidence in window (k)
-      average_observations_window <- base::sum(obs_iter$incidence, na.rm = TRUE) / k
+      # Calculate pooled incidence/proportion in window (k), weighted by trials
+      # and expressed on the original incidence denominator scale.
+      total_cases <- base::sum(obs_iter$cases, na.rm = TRUE)
+      total_population <- base::sum(obs_iter$population, na.rm = TRUE)
+      average_observations_window <- if (total_population > 0) {
+        (total_cases / total_population) * attr(tsd, "incidence_denominator")
+      } else {
+        NA_real_
+      }
     } else {
       # Calculate average cases in window (k)
       average_observations_window <- base::sum(obs_iter$cases, na.rm = TRUE) / k
     }
-    # Evaluate if average_incidence_window exceeds disease_threshold
-    average_observations_warning <- average_observations_window > disease_threshold
+    # Evaluate if average_incidence_window exceeds disease_threshold.
+    # If no threshold is supplied, no threshold-based onset can be detected,
+    # but keep the output schema consistent for downstream methods.
+    average_observations_warning <- if (is.na(disease_threshold)) {
+      FALSE
+    } else {
+      average_observations_window > disease_threshold
+    }
 
     # Give a seasonal_onset_alarm if both criteria are met
     seasonal_onset_alarm <- growth_warning & average_observations_warning
@@ -236,16 +267,17 @@ seasonal_onset <- function(
     )
   }
 
-  if (!is.na(disease_threshold)) {
-    # Extract seasons from onset_output and create seasonal_onset
-    res <- res |>
-      dplyr::mutate(
-        onset_flag = cumsum(.data$seasonal_onset_alarm),
-        seasonal_onset = .data$onset_flag == 1 & !duplicated(.data$onset_flag),
-        .by = "season"
-      ) |>
-      dplyr::select(-"onset_flag")
-  }
+  # Extract seasons from onset_output and create seasonal_onset. When no
+  # disease_threshold is supplied, seasonal_onset_alarm is FALSE for every row
+  # and seasonal_onset is therefore consistently present but always FALSE.
+  res <- res |>
+    dplyr::mutate(
+      seasonal_onset_alarm = tidyr::replace_na(.data$seasonal_onset_alarm, FALSE),
+      onset_flag = cumsum(.data$seasonal_onset_alarm),
+      seasonal_onset = .data$onset_flag == 1 & !duplicated(.data$onset_flag),
+      .by = "season"
+    ) |>
+    dplyr::select(-"onset_flag")
 
   # Create as tibble with an`tsd_onset` class
   # Add attributes, and keep attributes from the `tsd` class

--- a/R/to_time_series.R
+++ b/R/to_time_series.R
@@ -2,20 +2,26 @@
 #'
 #' @description
 #'
-#' This function takes `cases` and the corresponding date vector (`time`) and converts it into a `tsd` object, which is
-#' a time series data structure that can be used for time series analysis. If incidence is added, it will be used as
-#' observation in all future use of the `aedseo` package on the defined `tsd` object.
+#' This function takes observations and the corresponding date vector (`time`) and converts them into a `tsd` object,
+#' which is a time series data structure that can be used for time series analysis. For count data, supply `cases`
+#' or `incidence`/`population`. For binomial data, supply `successes`/`trials` or `proportion`/`trials`;
+#' downstream functions then keep observations on the proportion scale.
 #'
 #' Options:
 #'  - `incidence` can be calculated if also supplying `cases`, `population`, and `incidence_denominator`.
 #'  - `cases` can be calculated if also supplying `incidence`, `population` and `incidence_denominator`.
 #'  - If background population changes during the time series,
 #' it is used to adjust the growth rate in `seasonal_onset()`.
+#'  - `proportion` can be calculated if also supplying `successes` and `trials`.
+#'  - `successes` can be calculated if also supplying `proportion` and `trials`.
 #'
 #' @param cases `r rd_cases`
+#' @param successes An integer vector containing binomial successes. Use with `trials` for binomial data.
 #' @param incidence A numeric vector containing the time series incidences.
 #' With the given incidence_denominator.
+#' @param proportion A numeric vector containing binomial proportions in `[0, 1]` or percentages in `(1, 100]`. Use with `trials` for proportional/binomial data.
 #' @param population `r rd_population`
+#' @param trials An integer vector containing binomial trials. Use with `successes` or `proportion` for binomial data.
 #' @param incidence_denominator An integer >= 1, specifying the observations per incidence-denominator.
 #' @param time A date vector containing the corresponding dates.
 #' @param time_interval `r rd_time_interval`
@@ -25,6 +31,9 @@
 #'   - 'cases': The number of cases at the time point.
 #'   - 'incidence': The incidence per `incidence_denominator` at the time point. (optional)
 #'   - 'population': The background population for the cases at the time point. (optional)
+#'   - 'successes': The number of successes at the time point for binomial input. (optional)
+#'   - 'proportion': The proportion of successes per trial at the time point for binomial input. (optional)
+#'   - 'trials': The number of binomial trials at the time point for binomial input. (optional)
 #'
 #' @export
 #'
@@ -49,14 +58,51 @@
 #'   population = c(3000000, 3000000, 3000000, 3000000)
 #' )
 #'
+#' # Create a `tsd` object with binomial data
+#' tsd_binomial <- to_time_series(
+#'   successes = c(10, 12, 18, 25),
+#'   trials = c(100, 100, 120, 140),
+#'   time = seq(from = as.Date("2023-01-01"), by = "1 week", length.out = 4)
+#' )
+#'
 to_time_series <- function(                                     # nolint: cyclocomp_linter.
   cases = NULL,
+  successes = NULL,
   incidence = NULL,
+  proportion = NULL,
   population = NULL,
+  trials = NULL,
   incidence_denominator = if (is.null(population)) NA_real_ else 1e5,
   time,
   time_interval = c("weeks", "days", "months")
 ) {
+  if (!is.null(successes)) {
+    if (!is.null(cases)) {
+      stop("Use only one of `cases` or `successes`.")
+    }
+    cases <- successes
+  }
+  if (!is.null(trials)) {
+    if (!is.null(population)) {
+      stop("Use only one of `population` or `trials`.")
+    }
+    population <- trials
+  }
+  if (!is.null(proportion)) {
+    if (!is.null(incidence)) {
+      stop("Use only one of `incidence` or `proportion`.")
+    }
+    proportion <- dplyr::if_else(
+      proportion > 1 & proportion <= 100, proportion / 100, proportion
+    )
+    incidence <- proportion
+    incidence_denominator <- 1
+  }
+  binomial_input <- !is.null(successes) || !is.null(proportion) || !is.null(trials)
+  if (binomial_input) {
+    incidence_denominator <- 1
+  }
+
   # Check input arguments
   coll <- checkmate::makeAssertCollection()
   checkmate::assert_date(time, add = coll)
@@ -71,8 +117,24 @@ to_time_series <- function(                                     # nolint: cycloc
   if (is.null(cases) && is.null(population) && !is.null(incidence)) {
     coll$push("seasonal_onset() assumes integer counts, please supply population and incidence_denominator")
   }
+  if (!is.null(cases) && !is.null(population) && any(cases > population, na.rm = TRUE)) {
+    coll$push("`cases` must be less than or equal to `population` when both are supplied")
+  }
   if (is.null(population) && !is.na(incidence_denominator)) {
     coll$push("If incidence_denominator is assigned population should also be assigned")
+  }
+  if (!is.null(proportion) && any(incidence < 0 | incidence > 1, na.rm = TRUE)) {
+    coll$push("`proportion` must be between 0 and 1 or a percentage between 1 and 100")
+  }
+  if (binomial_input) {
+    if (is.null(population)) {
+      coll$push("`trials` (or `population`) must be supplied for binomial input")
+    } else {
+      checkmate::assert_true(all(population > 0, na.rm = TRUE), add = coll)
+    }
+    if (!is.null(cases)) {
+      checkmate::assert_true(all(cases >= 0, na.rm = TRUE), add = coll)
+    }
   }
   checkmate::reportAssertions(coll)
 
@@ -96,6 +158,19 @@ to_time_series <- function(                                     # nolint: cycloc
   if (is.null(cases) && !is.null(population) && !is.null(incidence) && !is.na(incidence_denominator)) {
     tbl <- tbl |>
       dplyr::mutate(cases = round((.data$incidence * .data$population) / incidence_denominator))
+  }
+
+  if (binomial_input && !is.null(cases) && !is.null(population)) {
+    tbl <- tbl |>
+      dplyr::mutate(incidence = .data$cases / .data$population)
+  }
+  if (binomial_input) {
+    tbl <- tibble::tibble(
+      time = time,
+      successes = tbl$cases,
+      proportion = tbl$incidence,
+      trials = tbl$population
+    )
   }
 
   # Create the time series data object

--- a/R/to_time_series.R
+++ b/R/to_time_series.R
@@ -19,7 +19,8 @@
 #' @param successes An integer vector containing binomial successes. Use with `trials` for binomial data.
 #' @param incidence A numeric vector containing the time series incidences.
 #' With the given incidence_denominator.
-#' @param proportion A numeric vector containing binomial proportions in `[0, 1]` or percentages in `(1, 100]`. Use with `trials` for proportional/binomial data.
+#' @param proportion A numeric vector containing binomial proportions in `[0, 1]` or percentages in `(1, 100]`.
+#' Use with `trials` for proportional/binomial data.
 #' @param population `r rd_population`
 #' @param trials An integer vector containing binomial trials. Use with `successes` or `proportion` for binomial data.
 #' @param incidence_denominator An integer >= 1, specifying the observations per incidence-denominator.

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -27,9 +27,12 @@ trigger a seasonal onset alarm. If the average observation count in a window of 
 \code{disease_threshold}, a seasonal onset alarm can be triggered. For burden levels it defines the per time-step
 disease threshold that has to be surpassed for the observation to be included in the level calculations.}
 
-\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.  This is passed to 'seasonal_onset()'.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate
+modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
+or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.  This is passed to 'seasonal_onset()'.}
 
-\item{family_quant}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
+\item{family_quant}{A character string specifying the family for modeling burden levels.
+Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}
@@ -64,7 +67,7 @@ A \code{tsd_onset} object containing:
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence interval.
 \item 'upper_growth_rate': The upper bound of the growth rate's confidence interval.
 \item 'growth_warning': Logical. Is the growth rate significantly higher than zero?
-\item 'average_observation_window': The average of cases or incidence within the time window.
+\item 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.
 \item 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?
 \item 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?
 \item 'skipped_window': Logical. Was the window skipped due to missing observations?
@@ -104,12 +107,14 @@ A \code{tsd_burden_levels} object containing:
 \item For 'weibull': Shape parameter.
 \item For 'lnorm': Mean of the log-transformed observations.
 \item For 'exp': Rate parameter.
+\item For 'beta': First shape parameter.
 }
 \item 'par_2':
 \itemize{
 \item For 'weibull': Scale parameter.
 \item For 'lnorm': Standard deviation of the log-transformed observations.
 \item For 'exp': Not applicable (set to NA).
+\item For 'beta': Second shape parameter.
 }
 }
 \item 'obj_value': The value of the objective function - (negative log-likelihood), which represent the minimised
@@ -120,6 +125,7 @@ objective function value from the optimisation. Smaller value equals better opti
 \item 'weibull': Uses the Weibull distribution for fitting.
 \item 'lnorm': Uses the Log-normal distribution for fitting.
 \item 'exp': Uses the Exponential distribution for fitting.
+\item 'beta': Uses the Beta distribution for proportional/binomial observations.
 }
 }
 \item 'disease_threshold': The input disease threshold, which is also the very low level.

--- a/man/combined_seasonal_output.Rd
+++ b/man/combined_seasonal_output.Rd
@@ -8,7 +8,7 @@ combined_seasonal_output(
   tsd,
   disease_threshold = 20,
   family = c("quasipoisson", "poisson"),
-  family_quant = c("lnorm", "weibull", "exp"),
+  family_quant = c("lnorm", "weibull", "exp", "beta"),
   season_start = 21,
   season_end = season_start - 1,
   only_current_season = TRUE,
@@ -31,8 +31,7 @@ disease threshold that has to be surpassed for the observation to be included in
 modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
 or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.  This is passed to 'seasonal_onset()'.}
 
-\item{family_quant}{A character string specifying the family for modeling burden levels.
-Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
+\item{family_quant}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}
@@ -67,7 +66,7 @@ A \code{tsd_onset} object containing:
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence interval.
 \item 'upper_growth_rate': The upper bound of the growth rate's confidence interval.
 \item 'growth_warning': Logical. Is the growth rate significantly higher than zero?
-\item 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.
+\item 'average_observation_window': The average of cases/incidence, or pooled proportion, within the time window.
 \item 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?
 \item 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?
 \item 'skipped_window': Logical. Was the window skipped due to missing observations?

--- a/man/estimate_disease_threshold.Rd
+++ b/man/estimate_disease_threshold.Rd
@@ -15,8 +15,8 @@ estimate_disease_threshold(
   pick_significant_sequence = c("longest", "earliest"),
   season_importance_decay = 0.8,
   conf_levels = c(0.25, 0.5, 0.75),
-  family = c("quasipoisson", "poisson"),
-  burden_family = c("lnorm", "weibull", "exp"),
+  family = NULL,
+  burden_family = NULL,
   ...
 )
 }
@@ -52,9 +52,12 @@ seasons, such that the influence of older seasons diminishes exponentially.}
 to be unique and in ascending order, the first percentile is the disease specific threshold.
 Specify one or three confidence levels e.g.: \code{c(0.25)} \code{c(0.25, 0.5, 0.75)}.}
 
-\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'. Passed to \code{seasonal_onset()} and then to \code{fit_growth_rate()}.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate
+modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
+or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.  Passed to \code{seasonal_onset()} and then to \code{fit_growth_rate()}.}
 
-\item{burden_family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'. Passed to \code{fit_percentiles()} as its \code{family} argument.}
+\item{burden_family}{A character string specifying the family for modeling burden levels.
+Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'. Passed to \code{fit_percentiles()} as its \code{family} argument.}
 
 \item{...}{Arguments passed to the \code{seasonal_onset()} or \code{fit_percentiles()} function.
 \code{only_current_season = FALSE} and \code{disease_threshold = NA_real_} cannot be changed in \code{seasonal_onset()}.}
@@ -65,7 +68,8 @@ An object of class \code{tsd_disease_threshold}, containing;
 }
 \description{
 This function estimates the disease specific threshold, based on previous seasons.
-If the disease threshold is estimated between ]0:1] it will be set to 1.
+For count/incidence data, thresholds estimated between ]0:1] are set to 1.
+For binomial/proportional data, thresholds remain on the proportion scale and beta percentiles are used by default.
 }
 \examples{
 # Generate seasonal data

--- a/man/estimate_disease_threshold.Rd
+++ b/man/estimate_disease_threshold.Rd
@@ -56,8 +56,7 @@ Specify one or three confidence levels e.g.: \code{c(0.25)} \code{c(0.25, 0.5, 0
 modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
 or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.  Passed to \code{seasonal_onset()} and then to \code{fit_growth_rate()}.}
 
-\item{burden_family}{A character string specifying the family for modeling burden levels.
-Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'. Passed to \code{fit_percentiles()} as its \code{family} argument.}
+\item{burden_family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'. Passed to \code{fit_percentiles()} as its \code{family} argument.}
 
 \item{...}{Arguments passed to the \code{seasonal_onset()} or \code{fit_percentiles()} function.
 \code{only_current_season = FALSE} and \code{disease_threshold = NA_real_} cannot be changed in \code{seasonal_onset()}.}

--- a/man/fit_growth_rate.Rd
+++ b/man/fit_growth_rate.Rd
@@ -2,23 +2,33 @@
 % Please edit documentation in R/fit_growth_rate.R
 \name{fit_growth_rate}
 \alias{fit_growth_rate}
-\title{Fit a growth rate model to time series cases.}
+\title{Fit a growth rate model to time series observations.}
 \usage{
 fit_growth_rate(
-  cases,
+  cases = NULL,
+  successes = NULL,
   population = NULL,
+  trials = NULL,
   level = 0.95,
-  family = c("quasipoisson", "poisson")
+  family = c("quasipoisson", "poisson", "quasibinomial", "binomial")
 )
 }
 \arguments{
-\item{cases}{An integer vector containing the time series cases.}
+\item{cases}{An integer vector containing the time series cases. For binomial data, use \code{successes} instead.}
 
-\item{population}{An integer vector containing the time series background population.}
+\item{successes}{An integer vector containing binomial successes. This is an alias for \code{cases} for
+binomial/quasibinomial models.}
+
+\item{population}{An integer vector containing the time series background population. For binomial data, use \code{trials} instead.}
+
+\item{trials}{An integer vector containing binomial trials. This is an alias for \code{population} for
+binomial/quasibinomial models.}
 
 \item{level}{The confidence level for parameter estimates, a numeric value between 0 and 1.}
 
-\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate
+modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
+or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.}
 }
 \value{
 A list containing:
@@ -31,8 +41,9 @@ confidence intervals.
 }
 }
 \description{
-This function fits a growth rate model to time series cases and provides parameter estimates along with
-confidence intervals.
+This function fits a growth rate model to time series observations and provides parameter estimates along with
+confidence intervals. For binomial data, supply successes and trials and use \code{family = "binomial"} or
+\code{family = "quasibinomial"}.
 }
 \examples{
 # Fit a growth rate model to a time series of counts
@@ -42,5 +53,12 @@ fit_growth_rate(
   cases = data,
   level = 0.95,
   family = "poisson"
+)
+
+# Fit a binomial growth rate model to successes out of trials
+fit_growth_rate(
+  successes = c(1, 2, 3, 4),
+  trials = c(10, 10, 10, 10),
+  family = "binomial"
 )
 }

--- a/man/fit_percentiles.Rd
+++ b/man/fit_percentiles.Rd
@@ -7,21 +7,22 @@
 fit_percentiles(
   weighted_observations,
   conf_levels = c(0.5, 0.9, 0.95),
-  family = c("lnorm", "weibull", "exp"),
+  family = NULL,
   optim_method = c("Nelder-Mead", "BFGS", "CG", "L-BFGS-B", "SANN", "Brent"),
   lower_optim = -Inf,
   upper_optim = Inf
 )
 }
 \arguments{
-\item{weighted_observations}{A tibble containing two columns of length n; \code{observation}, which contains either cases
-or incidences, and \code{weight}, which is the importance assigned to the observation. Higher weights indicate that an
+\item{weighted_observations}{A tibble containing two columns of length n; \code{observation}, which contains cases,
+incidences, or proportions, and \code{weight}, which is the importance assigned to the observation. Higher weights indicate that an
 observation has more influence on the model outcome, while lower weights reduce its impact.}
 
 \item{conf_levels}{A numeric vector specifying the confidence levels for parameter estimates. The values have
 to be unique and in ascending order, that is the lowest level is first and highest level is last.}
 
-\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
+\item{family}{A character string specifying the family for modeling burden levels.
+Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{optim_method}{A character string specifying the method to be used in the optimisation. Lookup \code{?optim::stats}
 for details about methods.
@@ -43,12 +44,14 @@ A list containing:
 \item For 'weibull': Shape parameter (k).
 \item For 'lnorm': Mean of the log-transformed observations.
 \item For 'exp': Rate parameter (rate).
+\item For 'beta': First shape parameter.
 }
 \item 'par_2':
 \itemize{
 \item For 'weibull': Scale parameter (scale).
 \item For 'lnorm': Standard deviation of the log-transformed observations.
 \item For 'exp': Not applicable (set to NA).
+\item For 'beta': Second shape parameter.
 }
 }
 \item 'obj_value': The value of the objective function - (negative log-likelihood), which represent the minimized
@@ -59,11 +62,12 @@ objective function value from the optimisation. Smaller value equals better opti
 \item 'weibull': Uses the Weibull distribution for fitting.
 \item 'lnorm': Uses the Log-normal distribution for fitting.
 \item 'exp': Uses the Exponential distribution for fitting.
+\item 'beta': Uses the Beta distribution for proportional/binomial observations.
 }
 }
 }
 \description{
-This function estimates the percentiles of weighted time series cases or incidences.
+This function estimates the percentiles of weighted time series cases, incidences, or proportions.
 The output contains the percentiles from the fitted distribution.
 }
 \examples{

--- a/man/fit_percentiles.Rd
+++ b/man/fit_percentiles.Rd
@@ -87,6 +87,6 @@ data_input <- tibble::tibble(
 fit_percentiles(
   weighted_observations = data_input,
   conf_levels = c(0.50, 0.90, 0.95),
-  family= "weibull"
+  family = "weibull"
 )
 }

--- a/man/fit_percentiles.Rd
+++ b/man/fit_percentiles.Rd
@@ -15,14 +15,13 @@ fit_percentiles(
 }
 \arguments{
 \item{weighted_observations}{A tibble containing two columns of length n; \code{observation}, which contains cases,
-incidences, or proportions, and \code{weight}, which is the importance assigned to the observation. Higher weights indicate that an
-observation has more influence on the model outcome, while lower weights reduce its impact.}
+incidences, or proportions, and \code{weight}, which is the importance assigned to the observation. Higher weights
+indicate that an observation has more influence on the model outcome, while lower weights reduce its impact.}
 
 \item{conf_levels}{A numeric vector specifying the confidence levels for parameter estimates. The values have
 to be unique and in ascending order, that is the lowest level is first and highest level is last.}
 
-\item{family}{A character string specifying the family for modeling burden levels.
-Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
+\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{optim_method}{A character string specifying the method to be used in the optimisation. Lookup \code{?optim::stats}
 for details about methods.

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -21,7 +21,8 @@ seasonal_burden_levels(
 \arguments{
 \item{tsd}{A \code{tsd} object containing time series data}
 
-\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', and 'exp'.}
+\item{family}{A character string specifying the family for modeling burden levels.
+Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}
@@ -75,12 +76,14 @@ A \code{tsd_burden_levels} object containing:
 \item For 'weibull': Shape parameter.
 \item For 'lnorm': Mean of the log-transformed observations.
 \item For 'exp': Rate parameter.
+\item For 'beta': First shape parameter.
 }
 \item 'par_2':
 \itemize{
 \item For 'weibull': Scale parameter.
 \item For 'lnorm': Standard deviation of the log-transformed observations.
 \item For 'exp': Not applicable (set to NA).
+\item For 'beta': Second shape parameter.
 }
 }
 \item 'obj_value': The value of the objective function - (negative log-likelihood), which represent the minimised
@@ -91,6 +94,7 @@ objective function value from the optimisation. Smaller value equals better opti
 \item 'weibull': Uses the Weibull distribution for fitting.
 \item 'lnorm': Uses the Log-normal distribution for fitting.
 \item 'exp': Uses the Exponential distribution for fitting.
+\item 'beta': Uses the Beta distribution for proportional/binomial observations.
 }
 }
 \item 'disease_threshold': The input disease threshold, which is also the very low level.

--- a/man/seasonal_burden_levels.Rd
+++ b/man/seasonal_burden_levels.Rd
@@ -6,7 +6,7 @@
 \usage{
 seasonal_burden_levels(
   tsd,
-  family = c("lnorm", "weibull", "exp"),
+  family = c("lnorm", "weibull", "exp", "beta"),
   season_start = 21,
   season_end = season_start - 1,
   method = c("intensity_levels", "peak_levels"),
@@ -21,8 +21,7 @@ seasonal_burden_levels(
 \arguments{
 \item{tsd}{A \code{tsd} object containing time series data}
 
-\item{family}{A character string specifying the family for modeling burden levels.
-Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
+\item{family}{A character string specifying the family for modeling burden levels. Choose between 'lnorm', 'weibull', 'exp', or 'beta'. Use 'beta' for proportional/binomial data. If \code{NULL}, defaults to 'beta' for proportional data and 'lnorm' otherwise. Proportional data must use 'beta'; non-proportional data cannot use 'beta'.}
 
 \item{season_start, season_end}{Integers giving the start and end weeks of the seasons to
 stratify the observations by.}

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -9,7 +9,7 @@ seasonal_onset(
   k = 5,
   level = 0.95,
   disease_threshold = NA_real_,
-  family = c("quasipoisson", "poisson"),
+  family = c("quasipoisson", "poisson", "quasibinomial", "binomial"),
   na_fraction_allowed = 0.4,
   season_start = NULL,
   season_end = season_start - 1,
@@ -28,7 +28,9 @@ seasonal_onset(
 onset alarm. If the average observation count in a window of size k exceeds \code{disease_threshold}, a seasonal
 onset alarm can be triggered.}
 
-\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate modeling. Choose between 'quasipoisson' and 'poisson'.}
+\item{family}{A character string, family-generator, or family object specifying the distribution family for growth-rate
+modeling. Choose between 'poisson', 'quasipoisson', 'binomial', or 'quasibinomial'. Use 'binomial'
+or 'quasibinomial' for binomial data supplied as \code{successes} and \code{trials}.}
 
 \item{na_fraction_allowed}{Numeric value between 0 and 1 specifying the fraction of observations in the window
 of size k that are allowed to be NA or zero, i.e. without cases, in onset calculations.}
@@ -50,7 +52,7 @@ A \code{tsd_onset} object containing:
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence interval.
 \item 'upper_growth_rate': The upper bound of the growth rate's confidence interval.
 \item 'growth_warning': Logical. Is the growth rate significantly higher than zero?
-\item 'average_observation_window': The average of cases or incidence within the time window.
+\item 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.
 \item 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?
 \item 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?
 \item 'skipped_window': Logical. Was the window skipped due to missing observations?
@@ -61,9 +63,11 @@ A \code{tsd_onset} object containing:
 }
 \description{
 This function performs automated and early detection of seasonal epidemic onsets on a \code{tsd} object.
-It estimates growth rates and calculates the average sum of cases in consecutive time intervals (\code{k}).
-If the time series data includes \code{population} it will be used as offset to adjust the growth rate in the glm,
-additionally the output will include incidence, population and average sum of incidence.
+It estimates growth rates and calculates the average observation in consecutive time intervals (\code{k}).
+For count/incidence data, Poisson/quasi-Poisson models use \code{population} as an offset when available.
+For binomial data created with \code{successes}/\code{trials} or \code{proportion}/\code{trials}, use \code{family = "binomial"}
+or \code{family = "quasibinomial"}; \code{trials} is used as the denominator and the rolling window is reported
+as a pooled proportion.
 }
 \examples{
 # Create a tibble object from sample data

--- a/man/seasonal_onset.Rd
+++ b/man/seasonal_onset.Rd
@@ -52,7 +52,7 @@ A \code{tsd_onset} object containing:
 \item 'lower_growth_rate': The lower bound of the growth rate's confidence interval.
 \item 'upper_growth_rate': The upper bound of the growth rate's confidence interval.
 \item 'growth_warning': Logical. Is the growth rate significantly higher than zero?
-\item 'average_observation_window': The average of cases/incidence, or pooled proportion for binomial data, within the time window.
+\item 'average_observation_window': The average of cases/incidence, or pooled proportion, within the time window.
 \item 'average_observation_warning': Logical. Does the average observations exceed the disease threshold?
 \item 'seasonal_onset_alarm': Logical. Is there a seasonal onset alarm?
 \item 'skipped_window': Logical. Was the window skipped due to missing observations?

--- a/man/to_time_series.Rd
+++ b/man/to_time_series.Rd
@@ -6,20 +6,29 @@
 \usage{
 to_time_series(
   cases = NULL,
+  successes = NULL,
   incidence = NULL,
+  proportion = NULL,
   population = NULL,
+  trials = NULL,
   incidence_denominator = if (is.null(population)) NA_real_ else 1e+05,
   time,
   time_interval = c("weeks", "days", "months")
 )
 }
 \arguments{
-\item{cases}{An integer vector containing the time series cases.}
+\item{cases}{An integer vector containing the time series cases. For binomial data, use \code{successes} instead.}
+
+\item{successes}{An integer vector containing binomial successes. Use with \code{trials} for binomial data.}
 
 \item{incidence}{A numeric vector containing the time series incidences.
 With the given incidence_denominator.}
 
-\item{population}{An integer vector containing the time series background population.}
+\item{proportion}{A numeric vector containing binomial proportions in \verb{[0, 1]} or percentages in \verb{(1, 100]}. Use with \code{trials} for proportional/binomial data.}
+
+\item{population}{An integer vector containing the time series background population. For binomial data, use \code{trials} instead.}
+
+\item{trials}{An integer vector containing binomial trials. Use with \code{successes} or \code{proportion} for binomial data.}
 
 \item{incidence_denominator}{An integer >= 1, specifying the observations per incidence-denominator.}
 
@@ -34,12 +43,16 @@ A \code{tsd} object containing:
 \item 'cases': The number of cases at the time point.
 \item 'incidence': The incidence per \code{incidence_denominator} at the time point. (optional)
 \item 'population': The background population for the cases at the time point. (optional)
+\item 'successes': The number of successes at the time point for binomial input. (optional)
+\item 'proportion': The proportion of successes per trial at the time point for binomial input. (optional)
+\item 'trials': The number of binomial trials at the time point for binomial input. (optional)
 }
 }
 \description{
-This function takes \code{cases} and the corresponding date vector (\code{time}) and converts it into a \code{tsd} object, which is
-a time series data structure that can be used for time series analysis. If incidence is added, it will be used as
-observation in all future use of the \code{aedseo} package on the defined \code{tsd} object.
+This function takes observations and the corresponding date vector (\code{time}) and converts them into a \code{tsd} object,
+which is a time series data structure that can be used for time series analysis. For count data, supply \code{cases}
+or \code{incidence}/\code{population}. For binomial data, supply \code{successes}/\code{trials} or \code{proportion}/\code{trials};
+downstream functions then keep observations on the proportion scale.
 
 Options:
 \itemize{
@@ -47,6 +60,8 @@ Options:
 \item \code{cases} can be calculated if also supplying \code{incidence}, \code{population} and \code{incidence_denominator}.
 \item If background population changes during the time series,
 it is used to adjust the growth rate in \code{seasonal_onset()}.
+\item \code{proportion} can be calculated if also supplying \code{successes} and \code{trials}.
+\item \code{successes} can be calculated if also supplying \code{proportion} and \code{trials}.
 }
 }
 \examples{
@@ -68,6 +83,13 @@ tsd_calculate_cases <- to_time_series(
   incidence = c(5, 7.8, 8, 8.5),
   time = seq(from = as.Date("2023-01-01"), by = "1 week", length.out = 4),
   population = c(3000000, 3000000, 3000000, 3000000)
+)
+
+# Create a `tsd` object with binomial data
+tsd_binomial <- to_time_series(
+  successes = c(10, 12, 18, 25),
+  trials = c(100, 100, 120, 140),
+  time = seq(from = as.Date("2023-01-01"), by = "1 week", length.out = 4)
 )
 
 }

--- a/man/to_time_series.Rd
+++ b/man/to_time_series.Rd
@@ -24,7 +24,8 @@ to_time_series(
 \item{incidence}{A numeric vector containing the time series incidences.
 With the given incidence_denominator.}
 
-\item{proportion}{A numeric vector containing binomial proportions in \verb{[0, 1]} or percentages in \verb{(1, 100]}. Use with \code{trials} for proportional/binomial data.}
+\item{proportion}{A numeric vector containing binomial proportions in \verb{[0, 1]} or percentages in \verb{(1, 100]}.
+Use with \code{trials} for proportional/binomial data.}
 
 \item{population}{An integer vector containing the time series background population. For binomial data, use \code{trials} instead.}
 

--- a/tests/testthat/test-estimate_disease_threshold.R
+++ b/tests/testthat/test-estimate_disease_threshold.R
@@ -146,6 +146,47 @@ test_that("Test that function returns NA when tsd is too short for the window si
   )
 })
 
+test_that("estimate_disease_threshold distinguishes binomial input from denominator-one incidence", {
+  time <- seq.Date(from = as.Date("2022-11-02"), by = 1, length.out = 3)
+
+  binomial_tsd <- to_time_series(
+    successes = c(1, 2, 3),
+    trials = c(10, 10, 10),
+    time = time
+  )
+  binomial_threshold <- estimate_disease_threshold(
+    tsd = binomial_tsd,
+    k = 4
+  )
+
+  expect_true(all(
+    c("successes", "trials", "proportion") %in% names(binomial_threshold$onset_output)
+  ))
+  expect_false(any(
+    c("cases", "population", "incidence") %in% names(binomial_threshold$onset_output)
+  ))
+  expect_equal(binomial_threshold$settings$family, "quasibinomial")
+
+  incidence_tsd <- to_time_series(
+    cases = c(1, 2, 3),
+    population = c(10, 10, 10),
+    incidence_denominator = 1,
+    time = time
+  )
+  incidence_threshold <- estimate_disease_threshold(
+    tsd = incidence_tsd,
+    k = 4
+  )
+
+  expect_true(all(
+    c("cases", "population", "incidence") %in% names(incidence_threshold$onset_output)
+  ))
+  expect_false(any(
+    c("successes", "trials", "proportion") %in% names(incidence_threshold$onset_output)
+  ))
+  expect_equal(incidence_threshold$settings$family, "quasipoisson")
+})
+
 test_that("family arguments are routed to onset and percentile fits", {
   skip_if_not_installed("withr")
   withr::local_seed(111)

--- a/tests/testthat/test-fit_growth_rate.R
+++ b/tests/testthat/test-fit_growth_rate.R
@@ -25,3 +25,31 @@ test_that("The growth rate models converge", {
   expect_true(object = fit_poisson$fit$converged)
   expect_true(object = fit_quasipoisson$fit$converged)
 })
+
+test_that("fit_growth_rate supports binomial and quasibinomial families", {
+  successes <- c(1, 2, 3, 4)
+  trials <- c(10, 10, 10, 10)
+
+  expect_s3_class(
+    fit_growth_rate(
+      successes = successes,
+      trials = trials,
+      family = "binomial"
+    )$fit,
+    "glm"
+  )
+
+  expect_s3_class(
+    fit_growth_rate(
+      successes = successes,
+      trials = trials,
+      family = "quasibinomial"
+    )$fit,
+    "glm"
+  )
+
+  expect_error(
+    fit_growth_rate(successes = successes, family = "binomial"),
+    "trials"
+  )
+})

--- a/tests/testthat/test-fit_percentiles.R
+++ b/tests/testthat/test-fit_percentiles.R
@@ -84,3 +84,19 @@ test_that("Test that when there is only one unique observation return NA and war
     rep(NA, 3)
   )
 })
+
+test_that("fit_percentiles defaults proportional observations to beta", {
+  weighted_observations <- tibble::tibble(
+    observation = c(0.1, 0.2, 0.3, 0.4),
+    weight = c(1, 1, 1, 1)
+  )
+
+  fit <- fit_percentiles(weighted_observations, conf_levels = c(0.25, 0.5, 0.75))
+  expect_equal(fit$family, "beta")
+  expect_true(all(fit$values >= 0 & fit$values <= 1))
+
+  expect_error(
+    fit_percentiles(weighted_observations, family = "lnorm"),
+    "Only the 'beta' family"
+  )
+})

--- a/tests/testthat/test-seasonal_onset.R
+++ b/tests/testthat/test-seasonal_onset.R
@@ -238,7 +238,7 @@ test_that("family works the same via name, generator or object", {
 
   expect_error(seasonal_onset(
     tsd = tsd_data,
-    family = stats::binomial,
+    family = 4,
   ))
 })
 

--- a/tests/testthat/test-to_time_series.R
+++ b/tests/testthat/test-to_time_series.R
@@ -92,3 +92,49 @@ test_that("cases vs. incidence input/conversion works as expected", {
   )
   expect_named(tsd_miss_cases, c("time", "incidence", "population", "cases"))
 })
+
+test_that("binomial input is converted to proportion-scale tsd", {
+  time <- seq(from = as.Date("2023-01-01"), by = "1 week", length.out = 3)
+
+  tsd_successes <- to_time_series(
+    successes = c(10L, 12L, 30L),
+    trials = c(100L, 120L, 150L),
+    time = time
+  )
+
+  expect_s3_class(tsd_successes, "tsd")
+  expect_named(tsd_successes, c("time", "successes", "proportion", "trials"))
+  expect_equal(tsd_successes$successes, c(10L, 12L, 30L))
+  expect_equal(tsd_successes$trials, c(100L, 120L, 150L))
+  expect_equal(tsd_successes$proportion, c(0.1, 0.1, 0.2))
+  expect_equal(attr(tsd_successes, "incidence_denominator"), 1)
+
+  tsd_proportion <- to_time_series(
+    proportion = c(10, 25, 0.5),
+    trials = c(100L, 200L, 20L),
+    time = time
+  )
+
+  expect_named(tsd_proportion, c("time", "successes", "proportion", "trials"))
+  expect_equal(tsd_proportion$successes, c(10, 50, 10))
+  expect_equal(tsd_proportion$proportion, c(0.1, 0.25, 0.5))
+  expect_equal(tsd_proportion$trials, c(100L, 200L, 20L))
+})
+
+test_that("binomial input validation catches invalid combinations", {
+  time <- seq(from = as.Date("2023-01-01"), by = "1 week", length.out = 2)
+
+  expect_error(
+    to_time_series(successes = c(1L, 2L), time = time),
+    "`trials` (or `population`) must be supplied for binomial input",
+    fixed = TRUE
+  )
+  expect_error(
+    to_time_series(successes = c(3L, 5L), trials = c(2L, 4L), time = time),
+    "less than or equal"
+  )
+  expect_error(
+    to_time_series(proportion = c(0.5, 101), trials = c(10L, 10L), time = time),
+    "between 0 and 1"
+  )
+})

--- a/vignettes/aedseo.Rmd
+++ b/vignettes/aedseo.Rmd
@@ -32,9 +32,12 @@ observations based on previous seasons.
 ### Seasonal data
 
 To apply the `aedseo` algorithm, data needs to be transformed into a `tsd` object.
-If you have your own data, the `to_time_series()` function can be used with the arguments: `cases`, `incidence`, `population`, `incidence_denominator`, `time` and `time_interval`.
-As default both `seasonal_onset()` and `seasonal_burden_levels()` use `cases`, but if `incidence` is in the `tsd` object the output will be in `incidence` instead.
-If `population` is additionally given as arguments the function will calculate the `incidence` per 100.000 (default for `incidence_denominator` which can be changed in input).
+If you have your own count data, the `to_time_series()` function can be used with `cases`, or with `incidence`, `population` and `incidence_denominator` to calculate cases or incidence.
+For binomial or proportional data, use `successes` together with `trials`, or `proportion` together with `trials`, instead of the count/incidence inputs (`cases`, `incidence`, `population` and `incidence_denominator`).
+The `time` argument is always required, regardless of whether the observations are counts, incidences, successes, or proportions.
+The `time_interval` argument is optional: if it is not specified, weekly spacing is assumed; specify it only when the observations are recorded at another supported interval, such as days or months.
+As default both `seasonal_onset()` and `seasonal_burden_levels()` use `cases`, but if `incidence` is in the `tsd` object the output will be in `incidence` instead; proportional input is kept on the proportion scale.
+If `population` is additionally given as arguments the function will calculate the `incidence` per 100.000 (default for `incidence_denominator` which can be changed in input). For binomial inputs, `trials` supplies the denominator and `incidence_denominator` is set to 1.
 In the following section, the application of the algorithm is shown with simulated cases created with the `generate_seasonal_data()`function.
 More information about the function can be found in the `vignette("generate_seasonal_wave")`.
 ```{r, include = FALSE}
@@ -76,7 +79,7 @@ In this example the disease-specific threshold is determined based on consecutiv
 Significant weeks are defined as those with a case count that has a significant positive growth rate.
 
 To capture short-term changes and fluctuations in the cases, a rolling window of size $k = 5$ is used to create subsets of the cases for model fitting,
-and the `quasipoisson` family is used to account for overdispersion.
+and the `quasipoisson` family is used to account for overdispersion. For binomial/proportional observations, use `successes`/`trials` or `proportion`/`trials` when creating the `tsd`, fit onset with `family = "binomial"` or `family = "quasibinomial"`, and estimate thresholds on the proportion scale.
 
 The `estimate_disease_threshold()` function can be used to automatically estimate the disease-specific threshold.
 As default it uses;

--- a/vignettes/burden_levels.Rmd
+++ b/vignettes/burden_levels.Rmd
@@ -139,15 +139,15 @@ burden_levels_df |>
 
 ## Methodology
 
-The methodology used to define the burden levels of seasonal epidemics is based on observations (cases or incidence) from previous seasons.
+The methodology used to define the burden levels of seasonal epidemics is based on observations (cases, incidence, or proportions) from previous seasons.
 Historical data from all available seasons is used to establish the levels for the current season.
 This is done by:
 
-- Using either cases or incidence as observations (default is `cases`, but if `incidence` is in the `tsd` object it will be used instead).
+- Using cases, incidence, or proportions as observations (default is `cases`, but if `incidence` is in the `tsd` object it will be used instead; binomial/proportional input remains on the proportion scale).
 - Using `n` highest (peak) observations from each season.
 - Selecting only observations if they surpass the disease-specific threshold.
 - Weighting the observations such that recent observations have a greater influence than older observations.
-- A proper distribution (log-normal, weibull and exponential are currently implemented) is fitted to the weighted
+- A proper distribution (log-normal, Weibull, exponential, or beta for proportional/binomial observations) is fitted to the weighted
  `n` peak observations. The selected distribution with the fitted parameters is used to calculate percentiles to be used as breakpoints.
 - Burden levels can be defined by two methods:
   - `peak_levels` which models the height of the seasonal peaks. Using the log-normal distribution without weights is similar
@@ -177,7 +177,7 @@ Conversely, if the data exhibit dramatic shifts from one season to the next, a l
 
 #### Distribution and optimisation
 The `family` argument is used to select which distribution the `n_peak` observations should be fitted to, users can
-choose between `lnorm`, `weibull` and `exp` distributions. The log-normal distribution theoretically
+choose between `lnorm`, `weibull`, `exp`, and `beta` distributions. Use `beta` for proportional/binomial observations on the `[0, 1]` scale; if `family = NULL`, proportional data default to `beta` and non-proportional data default to `lnorm`. The log-normal distribution theoretically
 aligns well with the nature of epidemic data, which often exhibits multiplicative growth patterns.
 In our optimisation process, we evaluated the distributions to determine their performance in fitting Danish non-sentinel
 cases and hospitalisation data for RSV, SARS-CoV-2 and Influenza (A and B). All three distributions had comparable

--- a/vignettes/burden_levels.Rmd
+++ b/vignettes/burden_levels.Rmd
@@ -12,6 +12,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+has_mem <- requireNamespace("mem", quietly = TRUE)
 ```
 
 ```{r setup, warning=FALSE, message=FALSE}
@@ -368,7 +369,10 @@ peak_levels_n_neg_t <- seasonal_burden_levels(
 ## Compare intensity_levels, peak_levels and mem algorithms
 
 [mem](https://github.com/lozalojo/mem) is run with default arguments.
-```{r}
+
+`r if (!has_mem) "The mem comparison is skipped when the optional mem package is not installed."`
+
+```{r, eval=has_mem}
 # Remove current season such as previous seasons predict for newest season
 previous_seasons <- tsd_data_all |>
   dplyr::mutate(season = epi_calendar(time)) |>
@@ -398,7 +402,7 @@ mem_thresholds <- previous_seasons |>
 ```
 
 ### aedseo  and mem levels
-```{r, echo = FALSE, fig.width=10, fig.height=8, dpi=300}
+```{r, echo = FALSE, eval=has_mem, fig.width=10, fig.height=8, dpi=300}
 #### Create data frame
 burden_levels_df <- tibble::tibble(
   Level = names(

--- a/vignettes/seasonal_onset.Rmd
+++ b/vignettes/seasonal_onset.Rmd
@@ -62,8 +62,10 @@ with the variance ($v$) being significantly larger than the mean. This biologica
 One approach is to employ quasi-Poisson regression, which assumes $v=\sigma\lambda$,
 or to use negative binomial regression (not implemented yet), which assumes $v=\lambda+\lambda^2/\theta$, where both $\sigma$ and $\theta$ are overdispersion parameters.
 
-If the background population changes during the time-span for the cases, the growth rate estimations can be adjusted
-by applying population as offset in the model.
+For binomial/proportional observations, create the `tsd` with `successes`/`trials` or `proportion`/`trials` and use `family = "binomial"` or `family = "quasibinomial"`. The model then uses `trials` as the denominator (successes out of trials), and the rolling average is reported as a pooled proportion.
+
+If the background population changes during the time-span for count/incidence data, the growth rate estimations can be adjusted
+by applying population as offset in Poisson/quasi-Poisson models.
 
 ## Applying the seasonal_onset algorithm
 


### PR DESCRIPTION
### Description

This PR adds support for binomial input data in the seasonal onset and disease threshold workflow.

The main motivation is to allow onset detection and disease burden estimation when observations are provided as successes out of trials, or as proportions with corresponding trial counts, rather than only as counts or incidence values.

### Changes

* Added support for binomial/proportional inputs in `to_time_series()`, including `successes`, `trials`, and `proportion`.

  * Calculates `successes` when `proportion` and `trials` are provided.
  * Sets `incidence_denominator = 1` for proportional data.

* Extended `fit_growth_rate()` to support binomial growth-rate modeling.

  * Added `successes` and `trials` as aliases for binomial data.
  * Added support for `binomial` and `quasibinomial` families.
  * Added validation for binomial inputs.
  * Fits a `cbind(successes, trials - successes)` response when a binomial family is used.

* Extended `fit_percentiles()` to support proportional burden-level estimation.

  * Added the `beta` family.
  * Automatically detects proportional data and defaults to `beta` when appropriate.
  * Enforces compatibility between the selected family and the input data.
  * Implements beta likelihood, initialization, and quantile calculation.

* Updated `estimate_disease_threshold()` for binomial/proportional workflows.

  * Selects default families depending on the content of the `tsd` object produced by `to_time_series()`.
  * Normalizes thresholds differently for count and binomial data to keep values on the appropriate scale.
  * Upweights proportional observations by the number of trials in the corresponding rolling window.
  * Formats onset outputs for binomial data by renaming fields to reflect `successes`, `trials`, and `proportion`.

* Updated `seasonal_onset()` to handle binomial-style columns.

  * Computes pooled proportions for rolling windows for both binomial and incidence-type data.
  * Ensures that `seasonal_onset` flags are computed consistently.

* Updated documentation and examples.

  * Revised documentation strings and return-value descriptions.
  * Updated vignettes to describe binomial/proportional support.
  * Documented the new `beta` burden-level family.

### Testing

* Ran the package unit tests with `devtools::test()`.
* The updated tests in `tests/testthat/test-fit_growth_rate.R` and `tests/testthat/test-fit_percentiles.R` passed.
* Existing `testthat` tests covering `seasonal_onset()` and related workflows were also run and passed under the updated behavior.
